### PR TITLE
Remove TEMPLATE_DEBUG setting. Fixes #57

### DIFF
--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -38,7 +38,6 @@
 import os
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 DATABASES = {
     'default': {


### PR DESCRIPTION
This has moved in 1.9, and defaults to the DEBUG setting anyway