### PR TITLE
Concurrent turns

### DIFF
--- a/aimmo-game/service.py
+++ b/aimmo-game/service.py
@@ -18,7 +18,8 @@ from simulation import map_generator
 from simulation.avatar.avatar_manager import AvatarManager
 from simulation.location import Location
 from simulation.game_state import GameState
-from simulation.turn_manager import TurnManager
+from simulation.turn_manager import ConcurrentTurnManager
+from simulation.turn_manager import SequentialTurnManager
 from simulation.worker_manager import WORKER_MANAGERS
 
 app = flask.Flask(__name__)
@@ -112,7 +113,7 @@ def run_game():
     my_map = map_generator.generate_map(10, 10, 0.1)
     player_manager = AvatarManager()
     game_state = GameState(my_map, player_manager)
-    turn_manager = TurnManager(game_state=game_state, end_turn_callback=send_world_update)
+    turn_manager = ConcurrentTurnManager(game_state=game_state, end_turn_callback=send_world_update)
     WorkerManagerClass = WORKER_MANAGERS[os.environ.get('WORKER_MANAGER', 'local')]
     worker_manager = WorkerManagerClass(
         game_state=game_state,

--- a/aimmo-game/service.py
+++ b/aimmo-game/service.py
@@ -13,7 +13,7 @@ from flask_socketio import SocketIO, emit
 
 from six.moves import range
 
-from simulation.turn_manager import game_state_provider
+from simulation.turn_manager import state_provider
 from simulation import map_generator
 from simulation.avatar.avatar_manager import AvatarManager
 from simulation.location import Location
@@ -55,7 +55,7 @@ def player_dict(avatar):
 
 
 def get_world_state():
-    with game_state_provider as game_state:
+    with state_provider as game_state:
         world = game_state.world_map
         num_cols = world.num_cols
         num_rows = world.num_rows

--- a/aimmo-game/simulation/action.py
+++ b/aimmo-game/simulation/action.py
@@ -22,8 +22,8 @@ class Action(object):
         return self._target_location
 
     def register(self, world_map):
-        if world_map.is_on_map(self._target_location):
-            world_map.get_cell(self._target_location).actions.append(self)
+        if world_map.is_on_map(self.target_location):
+            world_map.get_cell(self.target_location).actions.append(self)
 
     def process(self, world_map):
         if self.is_legal(world_map):
@@ -59,43 +59,51 @@ class MoveAction(Action):
         super(MoveAction, self).__init__(avatar)
 
     def is_legal(self, world_map):
-        return world_map.can_move_to(self._target_location)
+        return world_map.can_move_to(self.target_location)
 
     def process(self, world_map):
-        if self.is_legal(world_map):
-            self.chain(world_map, self)
-        else:
-            self.reject()
+        self.chain(world_map, {self.avatar.location})
 
     def apply(self, world_map):
-        event = MovedEvent(self.avatar.location, self._target_location)
+        event = MovedEvent(self.avatar.location, self.target_location)
         self.avatar.add_event(event)
 
         world_map.get_cell(self.avatar.location).avatar = None
-        self.avatar.location = self._target_location
-        world_map.get_cell(self._target_location).avatar = self.avatar
+        self.avatar.location = self.target_location
+        world_map.get_cell(self.target_location).avatar = self.avatar
         self.avatar.clear_action()
 
-        new_cell = world_map.get_cell(self._target_location)
+        new_cell = world_map.get_cell(self.target_location)
         if new_cell.pickup:
             # TODO:  extract pickup logic into pickup when adding multiple types
             self.avatar.health = min(10, self.avatar.health + new_cell.pickup.health_restored)
             new_cell.pickup = None
 
-    def chain(self, world_map, first):
-        if self.is_legal(world_map):
-            avatar = world_map.get_cell(self.target_location).avatar
-            if avatar is None or (avatar.action is not first and
-                                  avatar.action.chain(world_map, first)):
-                self.apply(world_map)
-                return True
-        self.reject()
-        return False
+        return True
+
+    def chain(self, world_map, visited):
+        if not self.is_legal(world_map):
+            return self.reject()
+
+        # Detect cycles
+        if self.target_location in visited:
+            return self.reject()
+
+        next_cell = world_map.get_cell(self.target_location)
+        if not next_cell.is_occupied:
+            return self.apply(world_map)
+
+        next_action = next_cell.avatar.action
+        if next_action.chain(world_map, visited | {self.target_location}):
+            return self.apply(world_map)
+
+        return self.reject()
 
     def reject(self):
-        event = FailedMoveEvent(self.avatar.location, self._target_location)
+        event = FailedMoveEvent(self.avatar.location, self.target_location)
         self.avatar.add_event(event)
         self.avatar.clear_action()
+        return False
 
 
 class AttackAction(Action):
@@ -105,13 +113,13 @@ class AttackAction(Action):
         super(AttackAction, self).__init__(avatar)
 
     def is_legal(self, world_map):
-        return True if world_map.attackable_avatar(self._target_location) else False
+        return True if world_map.attackable_avatar(self.target_location) else False
 
     def apply(self, world_map):
-        attacked_avatar = world_map.attackable_avatar(self._target_location)
+        attacked_avatar = world_map.attackable_avatar(self.target_location)
         damage_dealt = 1
         self.avatar.add_event(PerformedAttackEvent(attacked_avatar,
-                                                   self._target_location,
+                                                   self.target_location,
                                                    damage_dealt))
         attacked_avatar.add_event(ReceivedAttackEvent(self.avatar,
                                                       damage_dealt))
@@ -126,11 +134,11 @@ class AttackAction(Action):
             # Move responsibility for this to avatar.die() ?
             respawn_location = world_map.get_random_spawn_location()
             attacked_avatar.die(respawn_location)
-            world_map.get_cell(self._target_location).avatar = None
+            world_map.get_cell(self.target_location).avatar = None
             world_map.get_cell(respawn_location).avatar = attacked_avatar
 
     def reject(self):
-        self.avatar.add_event(FailedAttackEvent(self._target_location))
+        self.avatar.add_event(FailedAttackEvent(self.target_location))
         self.avatar.clear_action()
 
 ACTIONS = {

--- a/aimmo-game/simulation/action.py
+++ b/aimmo-game/simulation/action.py
@@ -31,13 +31,22 @@ class Action(object):
         if world_map.is_on_map(self._target_location):
             world_map.get_cell(self._target_location).actions.append(self)
 
+    def is_legal(self, world_map):
+        raise NotImplementedError('Abstract method')
+
     def apply(self, world_map):
+        raise NotImplementedError('Abstract method')
+
+    def reject(self):
         raise NotImplementedError('Abstract method')
 
 
 class WaitAction(Action):
     def __init__(self, avatar):
         super(WaitAction, self).__init__(avatar, priority=0)
+
+    def is_legal(self, world_map):
+        return True
 
     def apply(self, world_map):
         pass
@@ -49,24 +58,26 @@ class MoveAction(Action):
         self.direction = Direction(**direction)
         super(MoveAction, self).__init__(avatar, priority=2)
 
+    def is_legal(self, world_map):
+        return world_map.can_move_to(self._target_location)
+
     def apply(self, world_map):
-        if world_map.can_move_to(self._target_location):
+        event = MovedEvent(self._avatar.location, self._target_location)
+        self._avatar.add_event(event)
 
-            event = MovedEvent(self._avatar.location, self._target_location)
-            self._avatar.add_event(event)
+        world_map.get_cell(self._avatar.location).avatar = None
+        self._avatar.location = self._target_location
+        world_map.get_cell(self._target_location).avatar = self._avatar
 
-            world_map.get_cell(self._avatar.location).avatar = None
-            self._avatar.location = self._target_location
+        new_cell = world_map.get_cell(self._target_location)
+        if new_cell.pickup:
+            # TODO:  extract pickup logic into pickup when adding multiple types
+            self._avatar.health = min(10, self._avatar.health + new_cell.pickup.health_restored)
+            new_cell.pickup = None
 
-            new_cell = world_map.get_cell(self._target_location)
-            new_cell.avatar = self._avatar
-
-            if new_cell.pickup:
-                # TODO: potentially extract pickup logic into pickup when adding multiple types
-                self._avatar.health = min(10, self._avatar.health + new_cell.pickup.health_restored)
-                new_cell.pickup = None
-        else:
-            self._avatar.add_event(FailedMoveEvent(self._avatar.location, self._target_location))
+    def reject(self):
+        event = FailedMoveEvent(self._avatar.location, self._target_location)
+        self._avatar.add_event(event)
 
 
 class AttackAction(Action):
@@ -75,28 +86,32 @@ class AttackAction(Action):
         self.direction = Direction(**direction)
         super(AttackAction, self).__init__(avatar, priority=1)
 
+    def is_legal(self, world_map):
+        return True if world_map.attackable_avatar(self._target_location) else False
+
     def apply(self, world_map):
         attacked_avatar = world_map.attackable_avatar(self._target_location)
-        if attacked_avatar:
-            damage_dealt = 1
-            self._avatar.add_event(PerformedAttackEvent(attacked_avatar, self._target_location, damage_dealt))
-            attacked_avatar.add_event(ReceivedAttackEvent(self._avatar, damage_dealt))
-            attacked_avatar.health -= damage_dealt
-            LOGGER.debug('{} dealt {} damage to {}'.format(self.avatar, damage_dealt, attacked_avatar))
-            if attacked_avatar.health <= 0:
-                respawn_location = world_map.get_random_spawn_location()
-                attacked_avatar.die(respawn_location)
-                world_map.get_cell(self._target_location).avatar = None
-                world_map.get_cell(respawn_location).avatar = attacked_avatar
-        else:
-            self._avatar.add_event(FailedAttackEvent(self._target_location))
+        damage_dealt = 1
+        self._avatar.add_event(PerformedAttackEvent(attacked_avatar,
+                                                    self._target_location,
+                                                    damage_dealt))
+        attacked_avatar.add_event(ReceivedAttackEvent(self._avatar,
+                                                      damage_dealt))
+        attacked_avatar.health -= damage_dealt
 
+        LOGGER.debug('{} dealt {} damage to {}'.format(self._avatar,
+                                                       damage_dealt,
+                                                       attacked_avatar))
 
-# TODO: investigate moving this to after an action is handled - it is not specific to an action
-def _add_score_from_cell_if_needed(avatar, world_map):
-    cell = world_map.get_cell(avatar.location)
-    if cell.generates_score:
-        avatar.score += 1
+        if attacked_avatar.health <= 0:
+            # Move responsibility for this to avatar.die() ?
+            respawn_location = world_map.get_random_spawn_location()
+            attacked_avatar.die(respawn_location)
+            world_map.get_cell(self._target_location).avatar = None
+            world_map.get_cell(respawn_location).avatar = attacked_avatar
+
+    def reject(self):
+        self._avatar.add_event(FailedAttackEvent(self._target_location))
 
 ACTIONS = {
     'attack': AttackAction,

--- a/aimmo-game/simulation/action.py
+++ b/aimmo-game/simulation/action.py
@@ -40,7 +40,7 @@ class WaitAction(Action):
         super(WaitAction, self).__init__(avatar, priority=0)
 
     def apply(self, world_map):
-        _add_score_from_cell_if_needed(self._avatar, world_map)
+        pass
 
 
 class MoveAction(Action):
@@ -67,7 +67,6 @@ class MoveAction(Action):
                 new_cell.pickup = None
         else:
             self._avatar.add_event(FailedMoveEvent(self._avatar.location, self._target_location))
-        _add_score_from_cell_if_needed(self._avatar, world_map)
 
 
 class AttackAction(Action):
@@ -91,7 +90,6 @@ class AttackAction(Action):
                 world_map.get_cell(respawn_location).avatar = attacked_avatar
         else:
             self._avatar.add_event(FailedAttackEvent(self._target_location))
-        _add_score_from_cell_if_needed(self._avatar, world_map)
 
 
 # TODO: investigate moving this to after an action is handled - it is not specific to an action

--- a/aimmo-game/simulation/action.py
+++ b/aimmo-game/simulation/action.py
@@ -1,7 +1,6 @@
 from logging import getLogger
 from simulation.direction import Direction
 from simulation.event import FailedAttackEvent, FailedMoveEvent, MovedEvent, PerformedAttackEvent, ReceivedAttackEvent
-import simulation.world_map as world_map_module
 
 LOGGER = getLogger(__name__)
 

--- a/aimmo-game/simulation/action.py
+++ b/aimmo-game/simulation/action.py
@@ -7,59 +7,72 @@ LOGGER = getLogger(__name__)
 
 
 class Action(object):
-    def apply(self, game_state, avatar):
+    def __init__(self):
+        self._avatar = None
+
+    @property
+    def avatar(self):
+        return self._avatar
+
+    @avatar.setter
+    def avatar(self, value):
+        self._avatar = value
+
+    def apply(self, game_state):
         raise NotImplementedError('Abstract method')
 
 
 class WaitAction(Action):
-    def apply(self, game_state, avatar):
-        _add_score_from_cell_if_needed(avatar, game_state)
+    def apply(self, game_state):
+        _add_score_from_cell_if_needed(self.avatar, game_state)
 
 
 class MoveAction(Action):
     def __init__(self, direction):
+        super(MoveAction, self).__init__()
         # Untrusted data!
         self.direction = Direction(**direction)
 
-    def apply(self, game_state, avatar):
-        target_location = avatar.location + self.direction
+    def apply(self, game_state):
+        target_location = self.avatar.location + self.direction
         if game_state.world_map.can_move_to(target_location):
-            avatar.add_event(MovedEvent(avatar.location, target_location))
-            game_state.world_map.get_cell(avatar.location).avatar = None
-            avatar.location = target_location
+            self.avatar.add_event(MovedEvent(self.avatar.location, target_location))
+            game_state.world_map.get_cell(self.avatar.location).avatar = None
+            self.avatar.location = target_location
             new_cell = game_state.world_map.get_cell(target_location)
-            new_cell.avatar = avatar
+            new_cell.avatar = self.avatar
             if new_cell.pickup:
                 # TODO: potentially extract pickup logic into pickup when adding multiple types
-                avatar.health = min(10, avatar.health + new_cell.pickup.health_restored)
+                self.avatar.health = min(10, self.avatar.health + new_cell.pickup.health_restored)
                 new_cell.pickup = None
         else:
-            avatar.add_event(FailedMoveEvent(avatar.location, target_location))
-        _add_score_from_cell_if_needed(avatar, game_state)
+            self.avatar.add_event(FailedMoveEvent(self.avatar.location, target_location))
+        _add_score_from_cell_if_needed(self.avatar, game_state)
 
 
 class AttackAction(Action):
     def __init__(self, direction):
+        super(AttackAction, self).__init__()
         # Untrusted data!
         self.direction = Direction(**direction)
 
-    def apply(self, game_state, avatar):
-        target_location = avatar.location + self.direction
+    def apply(self, game_state):
+        target_location = self.avatar.location + self.direction
         attacked_avatar = game_state.world_map.get_cell(target_location).avatar
         if attacked_avatar:
             damage_dealt = 1
-            avatar.add_event(PerformedAttackEvent(attacked_avatar, target_location, damage_dealt))
-            attacked_avatar.add_event(ReceivedAttackEvent(avatar, damage_dealt))
+            self.avatar.add_event(PerformedAttackEvent(attacked_avatar, target_location, damage_dealt))
+            attacked_avatar.add_event(ReceivedAttackEvent(self.avatar, damage_dealt))
             attacked_avatar.health -= damage_dealt
-            LOGGER.debug('{} dealt {} damage to {}'.format(avatar, damage_dealt, attacked_avatar))
+            LOGGER.debug('{} dealt {} damage to {}'.format(self.avatar, damage_dealt, attacked_avatar))
             if attacked_avatar.health <= 0:
                 respawn_location = game_state.world_map.get_random_spawn_location()
                 attacked_avatar.die(respawn_location)
                 game_state.world_map.get_cell(target_location).avatar = None
                 game_state.world_map.get_cell(respawn_location).avatar = attacked_avatar
         else:
-            avatar.add_event(FailedAttackEvent(target_location))
-        _add_score_from_cell_if_needed(avatar, game_state)
+            self.avatar.add_event(FailedAttackEvent(target_location))
+        _add_score_from_cell_if_needed(self.avatar, game_state)
 
 
 # TODO: investigate moving this to after an action is handled - it is not specific to an action

--- a/aimmo-game/simulation/action.py
+++ b/aimmo-game/simulation/action.py
@@ -7,77 +7,97 @@ LOGGER = getLogger(__name__)
 
 
 class Action(object):
-    def __init__(self):
-        self._avatar = None
+    def __init__(self, avatar, priority):
+        self._avatar = avatar
+        self._priority = priority
+        try:
+            self._target_location = self._avatar.location + self.direction
+        except AttributeError:
+            self._target_location = self._avatar.location
 
     @property
     def avatar(self):
         return self._avatar
 
-    @avatar.setter
-    def avatar(self, value):
-        self._avatar = value
+    @property
+    def target_location(self):
+        return self._target_location
 
-    def apply(self, game_state):
+    # Wait actions are applied first, then attack actions, then move actions.
+    @property
+    def priority(self):
+        return self._priority
+
+    def target(self, world_map):
+        if world_map.is_on_map(self._target_location):
+            world_map.get_cell(self._target_location).actions.append(self)
+
+    def apply(self, world_map):
         raise NotImplementedError('Abstract method')
 
 
 class WaitAction(Action):
-    def apply(self, game_state):
-        _add_score_from_cell_if_needed(self.avatar, game_state)
+    def __init__(self, avatar):
+        super(WaitAction, self).__init__(avatar, priority=0)
+
+    def apply(self, world_map):
+        _add_score_from_cell_if_needed(self._avatar, world_map)
 
 
 class MoveAction(Action):
-    def __init__(self, direction):
-        super(MoveAction, self).__init__()
+    def __init__(self, avatar, direction):
         # Untrusted data!
         self.direction = Direction(**direction)
+        super(MoveAction, self).__init__(avatar, priority=2)
 
-    def apply(self, game_state):
-        target_location = self.avatar.location + self.direction
-        if game_state.world_map.can_move_to(target_location):
-            self.avatar.add_event(MovedEvent(self.avatar.location, target_location))
-            game_state.world_map.get_cell(self.avatar.location).avatar = None
-            self.avatar.location = target_location
-            new_cell = game_state.world_map.get_cell(target_location)
-            new_cell.avatar = self.avatar
+    def apply(self, world_map):
+        if world_map.can_move_to(self._target_location):
+
+            event = MovedEvent(self._avatar.location, self._target_location)
+            self._avatar.add_event(event)
+
+            world_map.get_cell(self._avatar.location).avatar = None
+            self._avatar.location = self._target_location
+
+            new_cell = world_map.get_cell(self._target_location)
+            new_cell.avatar = self._avatar
+
             if new_cell.pickup:
                 # TODO: potentially extract pickup logic into pickup when adding multiple types
-                self.avatar.health = min(10, self.avatar.health + new_cell.pickup.health_restored)
+                self._avatar.health = min(10, self._avatar.health + new_cell.pickup.health_restored)
                 new_cell.pickup = None
         else:
-            self.avatar.add_event(FailedMoveEvent(self.avatar.location, target_location))
-        _add_score_from_cell_if_needed(self.avatar, game_state)
+            self._avatar.add_event(FailedMoveEvent(self._avatar.location, self._target_location))
+        _add_score_from_cell_if_needed(self._avatar, world_map)
 
 
 class AttackAction(Action):
-    def __init__(self, direction):
-        super(AttackAction, self).__init__()
+    def __init__(self, avatar, direction):
         # Untrusted data!
         self.direction = Direction(**direction)
+        super(AttackAction, self).__init__(avatar, priority=1)
 
-    def apply(self, game_state):
-        target_location = self.avatar.location + self.direction
-        attacked_avatar = game_state.world_map.get_cell(target_location).avatar
+    def apply(self, world_map):
+        attacked_avatar = world_map.attackable_avatar(self._target_location)
         if attacked_avatar:
             damage_dealt = 1
-            self.avatar.add_event(PerformedAttackEvent(attacked_avatar, target_location, damage_dealt))
-            attacked_avatar.add_event(ReceivedAttackEvent(self.avatar, damage_dealt))
+            self._avatar.add_event(PerformedAttackEvent(attacked_avatar, self._target_location, damage_dealt))
+            attacked_avatar.add_event(ReceivedAttackEvent(self._avatar, damage_dealt))
             attacked_avatar.health -= damage_dealt
             LOGGER.debug('{} dealt {} damage to {}'.format(self.avatar, damage_dealt, attacked_avatar))
             if attacked_avatar.health <= 0:
-                respawn_location = game_state.world_map.get_random_spawn_location()
+                respawn_location = world_map.get_random_spawn_location()
                 attacked_avatar.die(respawn_location)
-                game_state.world_map.get_cell(target_location).avatar = None
-                game_state.world_map.get_cell(respawn_location).avatar = attacked_avatar
+                world_map.get_cell(self._target_location).avatar = None
+                world_map.get_cell(respawn_location).avatar = attacked_avatar
         else:
-            self.avatar.add_event(FailedAttackEvent(target_location))
-        _add_score_from_cell_if_needed(self.avatar, game_state)
+            self._avatar.add_event(FailedAttackEvent(self._target_location))
+        _add_score_from_cell_if_needed(self._avatar, world_map)
 
 
 # TODO: investigate moving this to after an action is handled - it is not specific to an action
-def _add_score_from_cell_if_needed(avatar, game_state):
-    cell = game_state.world_map.get_cell(avatar.location)
+def _add_score_from_cell_if_needed(avatar, world_map):
+    cell = world_map.get_cell(avatar.location)
     if cell.generates_score:
         avatar.score += 1
 

--- a/aimmo-game/simulation/action.py
+++ b/aimmo-game/simulation/action.py
@@ -25,6 +25,12 @@ class Action(object):
         if world_map.is_on_map(self._target_location):
             world_map.get_cell(self._target_location).actions.append(self)
 
+    def apply_if_legal(self, world_map):
+        if self.is_legal(world_map):
+            self.apply(world_map)
+        else:
+            self.reject()
+
     def is_legal(self, world_map):
         raise NotImplementedError('Abstract method')
 

--- a/aimmo-game/simulation/avatar/avatar_manager.py
+++ b/aimmo-game/simulation/avatar/avatar_manager.py
@@ -8,19 +8,22 @@ class AvatarManager(object):
     """
 
     def __init__(self):
-        self.avatarsById = {}
+        self.avatars_by_id = {}
 
     def add_avatar(self, player_id, worker_url, location):
         avatar = AvatarWrapper(location, player_id, worker_url, AvatarAppearance("#000", "#ddd", "#777", "#fff"))
-        self.avatarsById[player_id] = avatar
+        self.avatars_by_id[player_id] = avatar
         return avatar
 
+    def get_avatar(self, user_id):
+        return self.avatars_by_id[user_id]
+
     def remove_avatar(self, user_id):
-        del self.avatarsById[user_id]
+        del self.avatars_by_id[user_id]
 
     @property
     def avatars(self):
-        return self.avatarsById.viewvalues()
+        return self.avatars_by_id.viewvalues()
 
     @property
     def active_avatars(self):

--- a/aimmo-game/simulation/avatar/avatar_manager.py
+++ b/aimmo-game/simulation/avatar/avatar_manager.py
@@ -11,7 +11,7 @@ class AvatarManager(object):
         self.avatars_by_id = {}
 
     def add_avatar(self, player_id, worker_url, location):
-        avatar = AvatarWrapper(location, player_id, worker_url, AvatarAppearance("#000", "#ddd", "#777", "#fff"))
+        avatar = AvatarWrapper(player_id, location, worker_url, AvatarAppearance("#000", "#ddd", "#777", "#fff"))
         self.avatars_by_id[player_id] = avatar
         return avatar
 

--- a/aimmo-game/simulation/avatar/avatar_wrapper.py
+++ b/aimmo-game/simulation/avatar/avatar_wrapper.py
@@ -13,11 +13,11 @@ class AvatarWrapper(object):
     """
 
     def __init__(self, initial_location, player_id, worker_url, avatar_appearance):
+        self.player_id = player_id
         self.location = initial_location
         self.health = 5
         self.score = 0
         self.events = []
-        self.player_id = player_id
         self.avatar_appearance = avatar_appearance
         self.worker_url = worker_url
         self._action = None

--- a/aimmo-game/simulation/avatar/avatar_wrapper.py
+++ b/aimmo-game/simulation/avatar/avatar_wrapper.py
@@ -26,6 +26,10 @@ class AvatarWrapper(object):
     def action(self):
         return self._action
 
+    @property
+    def is_moving(self):
+        return isinstance(self.action, MoveAction)
+
     def decide_action(self, state_view):
         try:
             data = requests.post(self.worker_url, json=state_view).json()
@@ -45,9 +49,6 @@ class AvatarWrapper(object):
             else:
                 self._action = action
                 return True
-
-    def is_moving(self):
-        return isinstance(self.action, MoveAction)
 
     def clear_action(self):
         self._action = None

--- a/aimmo-game/simulation/avatar/avatar_wrapper.py
+++ b/aimmo-game/simulation/avatar/avatar_wrapper.py
@@ -1,7 +1,7 @@
 import logging
 import requests
 
-from simulation.action import ACTIONS
+from simulation.action import ACTIONS, MoveAction
 
 LOGGER = logging.getLogger(__name__)
 
@@ -45,6 +45,9 @@ class AvatarWrapper(object):
             else:
                 self._action = action
                 return True
+
+    def is_moving(self):
+        return isinstance(self.action, MoveAction)
 
     def clear_action(self):
         self._action = None

--- a/aimmo-game/simulation/avatar/avatar_wrapper.py
+++ b/aimmo-game/simulation/avatar/avatar_wrapper.py
@@ -1,3 +1,11 @@
+import logging
+import requests
+
+from simulation.action import ACTIONS
+
+LOGGER = logging.getLogger(__name__)
+
+
 class AvatarWrapper(object):
     """
     The application's view of a character, not to be confused with "Avatar",
@@ -12,6 +20,34 @@ class AvatarWrapper(object):
         self.player_id = player_id
         self.avatar_appearance = avatar_appearance
         self.worker_url = worker_url
+        self._action = None
+
+    @property
+    def action(self):
+        return self._action
+
+    def decide_action(self, state_view):
+        try:
+            data = requests.post(self.worker_url, json=state_view).json()
+        except ValueError as err:
+            LOGGER.info('Failed to get turn result: %s', err)
+            return False
+        else:
+            try:
+                action_data = data['action']
+                action_type = action_data['action_type']
+                action_args = action_data.get('options', {})
+                action_args['avatar'] = self
+                action = ACTIONS[action_type](**action_args)
+            except (KeyError, ValueError) as err:
+                LOGGER.info('Bad action data supplied: %s', err)
+                return False
+            else:
+                self._action = action
+                return True
+
+    def clear_action(self):
+        self._action = None
 
     def die(self, respawn_location):
         # TODO: extract settings for health and score loss on death

--- a/aimmo-game/simulation/avatar/avatar_wrapper.py
+++ b/aimmo-game/simulation/avatar/avatar_wrapper.py
@@ -12,7 +12,7 @@ class AvatarWrapper(object):
     the player-supplied code.
     """
 
-    def __init__(self, initial_location, player_id, worker_url, avatar_appearance):
+    def __init__(self, player_id, initial_location, worker_url, avatar_appearance):
         self.player_id = player_id
         self.location = initial_location
         self.health = 5

--- a/aimmo-game/simulation/direction.py
+++ b/aimmo-game/simulation/direction.py
@@ -9,6 +9,10 @@ class Direction:
         self.x = x
         self.y = y
 
+    @property
+    def dict(self):
+        return {'x': self.x, 'y': self.y}
+
     def __repr__(self):
         return 'Direction(x={}, y={})'.format(self.x, self.y)
 

--- a/aimmo-game/simulation/game_state.py
+++ b/aimmo-game/simulation/game_state.py
@@ -31,3 +31,7 @@ class GameState(object):
             return
         self.world_map.get_cell(avatar.location).avatar = None
         self.avatar_manager.remove_avatar(user_id)
+
+    def update_environment(self):
+        num_avatars = len(self.avatar_manager.active_avatars)
+        self.world_map.reconstruct_interactive_state(num_avatars)

--- a/aimmo-game/simulation/game_state.py
+++ b/aimmo-game/simulation/game_state.py
@@ -26,7 +26,7 @@ class GameState(object):
 
     def remove_avatar(self, user_id):
         try:
-            avatar = self.avatar_manager.avatarsById[user_id]
+            avatar = self.avatar_manager.get_avatar(user_id)
         except KeyError:
             return
         self.world_map.get_cell(avatar.location).avatar = None

--- a/aimmo-game/simulation/game_state.py
+++ b/aimmo-game/simulation/game_state.py
@@ -5,7 +5,6 @@ class GameState(object):
     """
     Encapsulates the entire game state, including avatars, their code, and the world.
     """
-
     def __init__(self, world_map, avatar_manager):
         self.world_map = world_map
         self.avatar_manager = avatar_manager
@@ -19,10 +18,10 @@ class GameState(object):
             }
         }
 
-    def add_avatar(self, user_id, worker_url):
-        spawn_location = self.world_map.get_random_spawn_location()
-        avatar = self.avatar_manager.add_avatar(user_id, worker_url, spawn_location)
-        self.world_map.get_cell(spawn_location).avatar = avatar
+    def add_avatar(self, user_id, worker_url, location=None):
+        location = self.world_map.get_random_spawn_location() if location is None else location
+        avatar = self.avatar_manager.add_avatar(user_id, worker_url, location)
+        self.world_map.get_cell(location).avatar = avatar
 
     def remove_avatar(self, user_id):
         try:

--- a/aimmo-game/simulation/map_generator.py
+++ b/aimmo-game/simulation/map_generator.py
@@ -7,7 +7,7 @@ from simulation.world_map import Cell, WorldMap
 from six.moves import zip, range
 
 
-def generate_map(height, width, obstacle_ratio):
+def generate_map(height, width, obstacle_ratio=0.1):
     grid = [[Cell(Location(x, y)) for y in range(height)] for x in range(width)]
     world_map = WorldMap(grid)
 

--- a/aimmo-game/simulation/turn_manager.py
+++ b/aimmo-game/simulation/turn_manager.py
@@ -89,20 +89,16 @@ class TurnManager(Thread):
         # Waits applied first, then attacks, then moves.
         avatars.sort(key=lambda a: PRIORITIES[type(a.action)])
 
+        locations_to_clear = {a.action.target_location for a in avatars
+                              if a.action is not None}
+
         for action in (a.action for a in avatars if a.action is not None):
             with state_provider as game_state:
-                if action.is_legal(game_state.world_map):
-                    try:
-                        action.chain(game_state.world_map, action)
-                    except AttributeError:
-                        action.apply(game_state.world_map)
-                else:
-                    action.reject()
+                action.process(game_state.world_map)
 
-        for avatar in avatars:
+        for location in locations_to_clear:
             with state_provider as game_state:
-                game_state.world_map.clear_cell_actions(avatar.action.target_location)
-                avatar.clear_action()
+                game_state.world_map.clear_cell_actions(location)
 
     def _register_action(self, avatar):
         '''

--- a/aimmo-game/simulation/turn_manager.py
+++ b/aimmo-game/simulation/turn_manager.py
@@ -58,7 +58,7 @@ class TurnManager(threading.Thread):
         for avatar in active_avatars:
             action = self._get_action(avatar)
             with game_state_provider as game_state:
-                action.apply(game_state, avatar)
+                action.apply(game_state)
 
         with game_state_provider as game_state:
             self._update_environment(game_state)

--- a/aimmo-game/simulation/turn_manager.py
+++ b/aimmo-game/simulation/turn_manager.py
@@ -49,6 +49,12 @@ class TurnManager(Thread):
         self.concurrent_turns = concurrent_turns
         super(TurnManager, self).__init__()
 
+    def run_turn(self):
+        if self.concurrent_turns:
+            self.run_concurrent_turn()
+        else:
+            self.run_sequential_turn()
+
     def run_sequential_turn(self):
         '''
         Get and apply each avatar's action in turn.
@@ -111,10 +117,7 @@ class TurnManager(Thread):
 
     def run(self):
         while True:
-            if self.concurrent_turns:
-                self.run_concurrent_turn()
-            else:
-                self.run_sequential_turn()
+            self.run_turn()
 
             with state_provider as game_state:
                 game_state.update_environment()

--- a/aimmo-game/simulation/world_map.py
+++ b/aimmo-game/simulation/world_map.py
@@ -190,7 +190,6 @@ class WorldMap(object):
 
         Throws:
             IndexError: if there are no possible locations.
-
         """
         return self._get_random_spawn_locations(1)[0].location
 
@@ -213,9 +212,10 @@ class WorldMap(object):
         '''
         Return the avatar attackable at the given location, or None.
         '''
-        if not self.is_on_map(target_location):
+        try:
+            cell = self.get_cell(target_location)
+        except ValueError:
             return None
-        cell = self.get_cell(target_location)
 
         if cell.avatar:
             return cell.avatar

--- a/aimmo-game/simulation/world_map.py
+++ b/aimmo-game/simulation/world_map.py
@@ -116,6 +116,13 @@ class WorldMap(object):
     def num_cells(self):
         return self.num_rows * self.num_cols
 
+    def apply_score(self):
+        for cell in self.score_cells():
+            try:
+                cell.avatar.score += 1
+            except AttributeError:
+                pass
+
     def reconstruct_interactive_state(self, num_avatars):
         self._expand(num_avatars)
         self._reset_score_locations(num_avatars)

--- a/aimmo-game/simulation/world_map.py
+++ b/aimmo-game/simulation/world_map.py
@@ -46,8 +46,8 @@ class Cell(object):
 
     def __repr__(self):
         return 'Cell({} h={} s={} a={} p={})'.format(
-                self.location, self.habitable, self.generates_score, self.avatar,
-                self.pickup)
+            self.location, self.habitable, self.generates_score, self.avatar,
+            self.pickup)
 
     def __eq__(self, other):
         return self.location == other.location
@@ -58,6 +58,10 @@ class Cell(object):
     @property
     def moves(self):
         return [move for move in self.actions if isinstance(move, MoveAction)]
+
+    @property
+    def is_occupied(self):
+        return self.avatar is not None
 
     def serialise(self):
         return {
@@ -199,14 +203,9 @@ class WorldMap(object):
             return False
         cell = self.get_cell(target_location)
 
-        if not cell.habitable:
-            return False
-        elif len(cell.moves) > 1:
-            return False
-        elif cell.avatar:
-            return cell.avatar.is_moving()
-        else:
-            return True
+        return (cell.habitable
+                and (not cell.is_occupied or cell.avatar.is_moving)
+                and len(cell.moves) <= 1)
 
     def attackable_avatar(self, target_location):
         '''

--- a/aimmo-game/simulation/world_map.py
+++ b/aimmo-game/simulation/world_map.py
@@ -1,8 +1,10 @@
 import math
 import random
 
-from location import Location
 from logging import getLogger
+
+from simulation.location import Location
+from simulation.action import MoveAction
 
 LOGGER = getLogger(__name__)
 
@@ -194,14 +196,15 @@ class WorldMap(object):
         Return the avatar attackable at the given location, or None.
         '''
         if not self.is_on_map(target_location):
-            return False
+            return None
         cell = self.get_cell(target_location)
 
         if cell.avatar:
             return cell.avatar
 
-        if len(cell.actions) == 1:
-            return cell.actions[0].avatar
+        moves = [action for action in cell.actions if isinstance(action, MoveAction)]
+        if len(moves) == 1:
+            return moves[0].avatar
 
         return None
 

--- a/aimmo-game/simulation/world_map.py
+++ b/aimmo-game/simulation/world_map.py
@@ -40,6 +40,7 @@ class Cell(object):
         self.generates_score = generates_score
         self.avatar = None
         self.pickup = None
+        self.actions = []
 
     def __repr__(self):
         return 'Cell({} h={} s={} a={} p={})'.format(
@@ -93,6 +94,13 @@ class WorldMap(object):
         cell = self.grid[location.x][location.y]
         assert cell.location == location, 'location lookup mismatch: arg={}, found={}'.format(location, cell.location)
         return cell
+
+    def clear_cell_actions(self, location):
+        try:
+            cell = self.get_cell(location)
+            cell.actions = []
+        except ValueError:
+            return
 
     @property
     def num_rows(self):
@@ -177,9 +185,25 @@ class WorldMap(object):
     def can_move_to(self, target_location):
         if not self.is_on_map(target_location):
             return False
-
         cell = self.get_cell(target_location)
-        return cell.habitable and not cell.avatar
+
+        return cell.habitable and not cell.avatar and len(cell.actions) == 1
+
+    def attackable_avatar(self, target_location):
+        '''
+        Return the avatar attackable at the given location, or None.
+        '''
+        if not self.is_on_map(target_location):
+            return False
+        cell = self.get_cell(target_location)
+
+        if cell.avatar:
+            return cell.avatar
+
+        if len(cell.actions) == 1:
+            return cell.actions[0].avatar
+
+        return None
 
     def __repr__(self):
         return repr(self.grid)

--- a/aimmo-game/simulation/world_map.py
+++ b/aimmo-game/simulation/world_map.py
@@ -55,6 +55,10 @@ class Cell(object):
     def __hash__(self):
         return hash(self.location)
 
+    @property
+    def moves(self):
+        return [move for move in self.actions if isinstance(move, MoveAction)]
+
     def serialise(self):
         return {
             'avatar': self.avatar.serialise() if self.avatar else None,
@@ -196,7 +200,14 @@ class WorldMap(object):
             return False
         cell = self.get_cell(target_location)
 
-        return cell.habitable and not cell.avatar and len(cell.actions) == 1
+        if not cell.habitable:
+            return False
+        elif len(cell.moves) > 1:
+            return False
+        elif cell.avatar:
+            return cell.avatar.is_moving()
+        else:
+            return True
 
     def attackable_avatar(self, target_location):
         '''
@@ -209,9 +220,8 @@ class WorldMap(object):
         if cell.avatar:
             return cell.avatar
 
-        moves = [action for action in cell.actions if isinstance(action, MoveAction)]
-        if len(moves) == 1:
-            return moves[0].avatar
+        if len(cell.moves) == 1:
+            return cell.moves[0].avatar
 
         return None
 

--- a/aimmo-game/tests/simulation/dummy_avatar.py
+++ b/aimmo-game/tests/simulation/dummy_avatar.py
@@ -1,30 +1,26 @@
 from __future__ import absolute_import
 
+import itertools
+
 from simulation.avatar.avatar_wrapper import AvatarWrapper
 from simulation.avatar.avatar_manager import AvatarManager
-from simulation.action import MoveAction
-from simulation import direction
+from simulation.action import MoveAction, WaitAction
+from simulation.direction import NORTH, EAST, SOUTH, WEST
 
 
 class DummyAvatarRunner(AvatarWrapper):
-    def __init__(self, initial_location, player_id):
+    def __init__(self, player_id, initial_location):
         # TODO: extract avatar state and state-altering methods into a new class.
         #       The new class is to be shared between DummyAvatarRunner and AvatarRunner
-        self.player_id = player_id
-        self.location = initial_location
-        self.health = 5
-        self.score = 0
-        self.events = []
+        super(DummyAvatarRunner, self).__init__(player_id, initial_location, None, None)
         self.times_died = 0
-        self._action = None
 
     def decide_action(self, state_view):
         self._action = self.handle_turn(state_view)
         return True
 
     def handle_turn(self, state_view):
-        next_action = MoveAction(self, direction.EAST.dict)
-        return next_action
+        raise NotImplementedError()
 
     def add_event(self, event):
         self.events.append(event)
@@ -37,9 +33,58 @@ class DummyAvatarRunner(AvatarWrapper):
         return 'Dummy'
 
 
+class WaitDummy(DummyAvatarRunner):
+    '''
+    Avatar that always waits.
+    '''
+    def handle_turn(self, state_view):
+        return WaitAction(self)
+
+
+class MoveDummy(DummyAvatarRunner):
+    '''
+    Avatar that always moves in one direction.
+    '''
+    def __init__(self, player_id, initial_location, direction):
+        super(MoveDummy, self).__init__(player_id, initial_location)
+        self._direction = direction
+
+    def handle_turn(self, state_view):
+        return MoveAction(self, self._direction.dict)
+
+
+class MoveNorthDummy(MoveDummy):
+    def __init__(self, player_id, initial_location):
+        super(MoveNorthDummy, self).__init__(player_id, initial_location, NORTH)
+
+
+class MoveEastDummy(MoveDummy):
+    def __init__(self, player_id, initial_location):
+        super(MoveEastDummy, self).__init__(player_id, initial_location, EAST)
+
+
+class MoveSouthDummy(MoveDummy):
+    def __init__(self, player_id, initial_location):
+        super(MoveSouthDummy, self).__init__(player_id, initial_location, SOUTH)
+
+
+class MoveWestDummy(MoveDummy):
+    def __init__(self, player_id, initial_location):
+        super(MoveWestDummy, self).__init__(player_id, initial_location, WEST)
+
+
 class DummyAvatarManager(AvatarManager):
-    def __init__(self, avatars):
-        self.avatars_by_id = {a.player_id: a for a in avatars}
+    def __init__(self, dummy_list=[]):
+        super(DummyAvatarManager, self).__init__()
+        self.dummy_list = dummy_list
+
+    def add_avatar(self, player_id, worker_url, location):
+        try:
+            dummy = self.dummy_list.pop(0)
+        except IndexError:
+            dummy = WaitDummy
+        self.avatars_by_id[player_id] = dummy(player_id, location)
+        return self.avatars_by_id[player_id]
 
     def add_avatar_directly(self, avatar):
         self.avatars_by_id[avatar.player_id] = avatar

--- a/aimmo-game/tests/simulation/dummy_avatar.py
+++ b/aimmo-game/tests/simulation/dummy_avatar.py
@@ -1,18 +1,21 @@
 from __future__ import absolute_import
+
+from simulation.avatar.avatar_wrapper import AvatarWrapper
 from simulation.action import MoveAction
 from simulation import direction
 
 
-class DummyAvatarRunner(object):
+class DummyAvatarRunner(AvatarWrapper):
     def __init__(self, initial_location, player_id):
         # TODO: extract avatar state and state-altering methods into a new class.
         #       The new class is to be shared between DummyAvatarRunner and AvatarRunner
+        self.player_id = player_id
+        self.location = initial_location
         self.health = 5
         self.score = 0
-        self.location = initial_location
-        self.player_id = player_id
         self.events = []
         self.times_died = 0
+        self._action = None
 
     def handle_turn(self, state):
         next_action = MoveAction(direction.EAST)

--- a/aimmo-game/tests/simulation/dummy_avatar.py
+++ b/aimmo-game/tests/simulation/dummy_avatar.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from simulation.avatar.avatar_wrapper import AvatarWrapper
+from simulation.avatar.avatar_manager import AvatarManager
 from simulation.action import MoveAction
 from simulation import direction
 
@@ -17,12 +18,12 @@ class DummyAvatarRunner(AvatarWrapper):
         self.times_died = 0
         self._action = None
 
-    def handle_turn(self, state):
-        next_action = MoveAction(direction.EAST)
+    def decide_action(self, state_view):
+        self._action = self.handle_turn(state_view)
+        return True
 
-        # Reset event log
-        self.events = []
-
+    def handle_turn(self, state_view):
+        next_action = MoveAction(self, direction.EAST.dict)
         return next_action
 
     def add_event(self, event):
@@ -34,3 +35,11 @@ class DummyAvatarRunner(AvatarWrapper):
 
     def serialise(self):
         return 'Dummy'
+
+
+class DummyAvatarManager(AvatarManager):
+    def __init__(self, avatars):
+        self.avatars_by_id = {a.player_id: a for a in avatars}
+
+    def add_avatar_directly(self, avatar):
+        self.avatars_by_id[avatar.player_id] = avatar

--- a/aimmo-game/tests/simulation/dummy_avatar.py
+++ b/aimmo-game/tests/simulation/dummy_avatar.py
@@ -8,11 +8,11 @@ from simulation.action import MoveAction, WaitAction
 from simulation.direction import NORTH, EAST, SOUTH, WEST
 
 
-class DummyAvatarRunner(AvatarWrapper):
+class DummyAvatar(AvatarWrapper):
     def __init__(self, player_id, initial_location):
         # TODO: extract avatar state and state-altering methods into a new class.
         #       The new class is to be shared between DummyAvatarRunner and AvatarRunner
-        super(DummyAvatarRunner, self).__init__(player_id, initial_location, None, None)
+        super(DummyAvatar, self).__init__(player_id, initial_location, None, None)
         self.times_died = 0
 
     def decide_action(self, state_view):
@@ -33,7 +33,7 @@ class DummyAvatarRunner(AvatarWrapper):
         return 'Dummy'
 
 
-class WaitDummy(DummyAvatarRunner):
+class WaitDummy(DummyAvatar):
     '''
     Avatar that always waits.
     '''
@@ -41,7 +41,7 @@ class WaitDummy(DummyAvatarRunner):
         return WaitAction(self)
 
 
-class MoveDummy(DummyAvatarRunner):
+class MoveDummy(DummyAvatar):
     '''
     Avatar that always moves in one direction.
     '''

--- a/aimmo-game/tests/simulation/maps.py
+++ b/aimmo-game/tests/simulation/maps.py
@@ -24,7 +24,8 @@ class InfiniteMap(world_map.WorldMap):
         self._cell_cache = {}
         [self.get_cell(Location(x, y)) for x in range(5) for y in range(5)]
 
-    def can_move_to(self, target_location):
+    def is_on_map(self, target_location):
+        self.get_cell(target_location)
         return True
 
     def all_cells(self):

--- a/aimmo-game/tests/simulation/maps.py
+++ b/aimmo-game/tests/simulation/maps.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
-from simulation import world_map
+
 from simulation.location import Location
-from simulation.world_map import Cell
+from simulation.world_map import Cell, WorldMap
 
 
 class MockCell(Cell):
@@ -19,7 +19,7 @@ class MockCell(Cell):
         return self is other
 
 
-class InfiniteMap(world_map.WorldMap):
+class InfiniteMap(WorldMap):
     def __init__(self):
         self._cell_cache = {}
         [self.get_cell(Location(x, y)) for x in range(5) for y in range(5)]
@@ -35,7 +35,7 @@ class InfiniteMap(world_map.WorldMap):
         return self._cell_cache.setdefault(location, Cell(location))
 
 
-class EmptyMap(world_map.WorldMap):
+class EmptyMap(WorldMap):
     def __init__(self):
         pass
 
@@ -46,7 +46,7 @@ class EmptyMap(world_map.WorldMap):
         return iter(())
 
     def get_cell(self, location):
-        return world_map.Cell(location)
+        return Cell(location)
 
 
 class ScoreOnOddColumnsMap(InfiniteMap):
@@ -55,14 +55,14 @@ class ScoreOnOddColumnsMap(InfiniteMap):
         return self._cell_cache.setdefault(location, default_cell)
 
 
-class AvatarMap(world_map.WorldMap):
+class AvatarMap(WorldMap):
     def __init__(self, avatar):
         self._avatar = avatar
         self._cell_cache = {}
 
     def get_cell(self, location):
         if location not in self._cell_cache:
-            cell = world_map.Cell(location)
+            cell = Cell(location)
             cell.avatar = self._avatar
             self._cell_cache[location] = cell
         return self._cell_cache[location]

--- a/aimmo-game/tests/simulation/maps.py
+++ b/aimmo-game/tests/simulation/maps.py
@@ -6,13 +6,14 @@ from simulation.world_map import Cell
 
 class MockCell(Cell):
     def __init__(self, location=1, habitable=True, generates_score=False,
-                 avatar=None, pickup=None, name=None):
+                 avatar=None, pickup=None, name=None, actions=[]):
         self.location = location
         self.habitable = habitable
         self.generates_score = generates_score
         self.avatar = avatar
         self.pickup = pickup
         self.name = name
+        self.actions = actions
 
     def __eq__(self, other):
         return self is other
@@ -20,16 +21,17 @@ class MockCell(Cell):
 
 class InfiniteMap(world_map.WorldMap):
     def __init__(self):
-        pass
+        self._cell_cache = {}
+        [self.get_cell(Location(x, y)) for x in range(5) for y in range(5)]
 
     def can_move_to(self, target_location):
         return True
 
     def all_cells(self):
-        yield world_map.Cell(Location(0, 0))
+        return (cell for cell in self._cell_cache.values())
 
     def get_cell(self, location):
-        return world_map.Cell(location)
+        return self._cell_cache.setdefault(location, Cell(location))
 
 
 class EmptyMap(world_map.WorldMap):
@@ -48,10 +50,8 @@ class EmptyMap(world_map.WorldMap):
 
 class ScoreOnOddColumnsMap(InfiniteMap):
     def get_cell(self, location):
-        if location.x % 2 == 0:
-            return world_map.Cell(location)
-        else:
-            return world_map.Cell(location, habitable=True, generates_score=True)
+        default_cell = Cell(location, generates_score=(location.x % 2 == 1))
+        return self._cell_cache.setdefault(location, default_cell)
 
 
 class AvatarMap(world_map.WorldMap):

--- a/aimmo-game/tests/simulation/test_action.py
+++ b/aimmo-game/tests/simulation/test_action.py
@@ -23,21 +23,24 @@ class TestAction(unittest.TestCase):
 
     def test_successful_move_north_action(self):
         game_state = GameState(InfiniteMap(), self.avatar_manager)
-        action.MoveAction({'x': 0, 'y': 1}).apply(game_state, self.avatar)
+        action.MoveAction(self.avatar, {'x': 0, 'y': 1}).apply_if_legal(game_state.world_map)
 
+        target_cell = game_state.world_map.get_cell(NORTH_OF_ORIGIN)
         self.assertEqual(self.avatar.location, NORTH_OF_ORIGIN)
+        self.assertEqual(self.avatar, target_cell.avatar)
+
         self.assertEqual(self.avatar.events, [event.MovedEvent(ORIGIN, NORTH_OF_ORIGIN)])
 
     def test_successful_move_east_action(self):
         game_state = GameState(InfiniteMap(), self.avatar_manager)
-        action.MoveAction({'x': 1, 'y': 0}).apply(game_state, self.avatar)
+        action.MoveAction(self.avatar, {'x': 1, 'y': 0}).apply_if_legal(game_state.world_map)
 
         self.assertEqual(self.avatar.location, EAST_OF_ORIGIN)
         self.assertEqual(self.avatar.events, [event.MovedEvent(ORIGIN, EAST_OF_ORIGIN)])
 
     def test_failed_move_action(self):
         game_state = GameState(EmptyMap(), self.avatar_manager)
-        action.MoveAction({'x': 0, 'y': 1}).apply(game_state, self.avatar)
+        action.MoveAction(self.avatar, {'x': 0, 'y': 1}).apply_if_legal(game_state.world_map)
 
         self.assertEqual(self.avatar.location, ORIGIN)
         self.assertEqual(self.avatar.events, [event.FailedMoveEvent(ORIGIN, NORTH_OF_ORIGIN)])
@@ -46,13 +49,16 @@ class TestAction(unittest.TestCase):
         game_state = GameState(ScoreOnOddColumnsMap(), self.avatar_manager)
         self.assertEqual(self.avatar.score, 0)
 
-        action.MoveAction({'x': 1, 'y': 0}).apply(game_state, self.avatar)
+        action.MoveAction(self.avatar, {'x': 1, 'y': 0}).apply_if_legal(game_state.world_map)
+        game_state.world_map.apply_score()
         self.assertEqual(self.avatar.score, 1)
 
-        action.MoveAction({'x': 1, 'y': 0}).apply(game_state, self.avatar)
+        action.MoveAction(self.avatar, {'x': 1, 'y': 0}).apply_if_legal(game_state.world_map)
+        game_state.world_map.apply_score()
         self.assertEqual(self.avatar.score, 1)
 
-        action.MoveAction({'x': 1, 'y': 0}).apply(game_state, self.avatar)
+        action.MoveAction(self.avatar, {'x': 1, 'y': 0}).apply_if_legal(game_state.world_map)
+        game_state.world_map.apply_score()
         self.assertEqual(self.avatar.score, 2)
 
     @unittest.skip("Implement after changes")
@@ -62,7 +68,7 @@ class TestAction(unittest.TestCase):
 
     def test_successful_attack_action(self):
         game_state = GameState(AvatarMap(self.other_avatar), self.avatar_manager)
-        action.AttackAction({'x': 0, 'y': 1}).apply(game_state, self.avatar)
+        action.AttackAction(self.avatar, {'x': 0, 'y': 1}).apply_if_legal(game_state.world_map)
 
         target_location = NORTH_OF_ORIGIN
         damage_dealt = 1
@@ -82,7 +88,7 @@ class TestAction(unittest.TestCase):
 
     def test_failed_attack_action(self):
         game_state = GameState(InfiniteMap(), self.avatar_manager)
-        action.AttackAction({'x': 0, 'y': 1}).apply(game_state, self.avatar)
+        action.AttackAction(self.avatar, {'x': 0, 'y': 1}).apply_if_legal(game_state.world_map)
 
         target_location = NORTH_OF_ORIGIN
 
@@ -94,7 +100,7 @@ class TestAction(unittest.TestCase):
     def test_avatar_dies(self):
         self.other_avatar.health = 1
         game_state = GameState(AvatarMap(self.other_avatar), self.avatar_manager)
-        action.AttackAction({'x': 0, 'y': 1}).apply(game_state, self.avatar)
+        action.AttackAction(self.avatar, {'x': 0, 'y': 1}).apply_if_legal(game_state.world_map)
 
         target_location = NORTH_OF_ORIGIN
         damage_dealt = 1
@@ -113,5 +119,5 @@ class TestAction(unittest.TestCase):
 
     def test_no_move_in_wait(self):
         game_state = GameState(InfiniteMap(), self.avatar_manager)
-        action.WaitAction().apply(game_state, self.avatar)
+        action.WaitAction(self.avatar).apply_if_legal(game_state.world_map)
         self.assertEqual(self.avatar.location, ORIGIN)

--- a/aimmo-game/tests/simulation/test_game_state.py
+++ b/aimmo-game/tests/simulation/test_game_state.py
@@ -1,18 +1,9 @@
 from __future__ import absolute_import
 from .maps import InfiniteMap, AvatarMap, EmptyMap
 from .dummy_avatar import DummyAvatarRunner
+from .dummy_avatar import DummyAvatarManager
 from simulation.game_state import GameState
 from unittest import TestCase
-
-
-class EmptyAvatarManager(object):
-    avatarsById = {}
-
-    def remove_avatar(self, id):
-        del self.avatarsById[id]
-
-    def add_avatar(self, id, url, location):
-        self.avatarsById[id] = DummyAvatarRunner(location, id)
 
 
 class FogToEmpty(object):
@@ -22,36 +13,36 @@ class FogToEmpty(object):
 
 class TestGameState(TestCase):
     def test_remove_non_existant_avatar(self):
-        state = GameState(None, EmptyAvatarManager())
+        state = GameState(None, DummyAvatarManager([]))
         state.remove_avatar(10)
 
     def test_remove_avatar(self):
         map = InfiniteMap()
-        manager = EmptyAvatarManager()
+        manager = DummyAvatarManager([])
 
         avatar = DummyAvatarRunner((0, 0), 1)
         other_avatar = DummyAvatarRunner((0, 0), 2)
         other_avatar.marked = True
-        manager.avatarsById[1] = avatar
-        manager.avatarsById[2] = other_avatar
+        manager.add_avatar_directly(avatar)
+        manager.add_avatar_directly(other_avatar)
 
         state = GameState(map, manager)
         state.remove_avatar(1)
 
-        self.assertTrue(manager.avatarsById[2].marked)
-        self.assertNotIn(1, manager.avatarsById)
+        self.assertTrue(manager.avatars_by_id[2].marked)
+        self.assertNotIn(1, manager.avatars_by_id)
         self.assertEqual(map.get_cell((0, 0)).avatar, None)
 
     def test_add_avatar(self):
-        state = GameState(AvatarMap(None), EmptyAvatarManager())
+        state = GameState(AvatarMap(None), DummyAvatarManager([]))
         state.add_avatar(7, 'test')
-        self.assertIn(7, state.avatar_manager.avatarsById)
-        avatar = state.avatar_manager.avatarsById[7]
+        self.assertIn(7, state.avatar_manager.avatars_by_id)
+        avatar = state.avatar_manager.avatars_by_id[7]
         self.assertEqual(avatar.location.x, 10)
         self.assertEqual(avatar.location.y, 10)
 
     def test_fog_of_war(self):
-        state = GameState(InfiniteMap(), EmptyAvatarManager())
+        state = GameState(InfiniteMap(), DummyAvatarManager([]))
         view = state.get_state_for(DummyAvatarRunner(None, None), FogToEmpty())
         self.assertEqual(len(view['world_map']['cells']), 0)
         self.assertEqual(view['avatar_state'], 'Dummy')

--- a/aimmo-game/tests/simulation/test_game_state.py
+++ b/aimmo-game/tests/simulation/test_game_state.py
@@ -6,7 +6,7 @@ from simulation.game_state import GameState
 from simulation.location import Location
 
 from .maps import InfiniteMap, AvatarMap, EmptyMap
-from .dummy_avatar import DummyAvatarRunner
+from .dummy_avatar import DummyAvatar
 from .dummy_avatar import DummyAvatarManager
 
 
@@ -25,8 +25,8 @@ class TestGameState(TestCase):
         manager = DummyAvatarManager()
         game_state = GameState(world_map, manager)
 
-        avatar1 = DummyAvatarRunner(1, Location(0, 0))
-        avatar2 = DummyAvatarRunner(2, Location(1, 1))
+        avatar1 = DummyAvatar(1, Location(0, 0))
+        avatar2 = DummyAvatar(2, Location(1, 1))
         avatar2.marked = True
 
         manager.add_avatar_directly(avatar1)
@@ -52,6 +52,6 @@ class TestGameState(TestCase):
 
     def test_fog_of_war(self):
         state = GameState(InfiniteMap(), DummyAvatarManager())
-        view = state.get_state_for(DummyAvatarRunner(None, None), FogToEmpty())
+        view = state.get_state_for(DummyAvatar(None, None), FogToEmpty())
         self.assertEqual(len(view['world_map']['cells']), 0)
         self.assertEqual(view['avatar_state'], 'Dummy')

--- a/aimmo-game/tests/simulation/test_turn_manager.py
+++ b/aimmo-game/tests/simulation/test_turn_manager.py
@@ -4,7 +4,7 @@ import unittest
 from simulation.avatar.avatar_appearance import AvatarAppearance
 from simulation.game_state import GameState
 from simulation.location import Location
-from simulation.turn_manager import TurnManager
+from simulation.turn_manager import ConcurrentTurnManager
 
 from .maps import InfiniteMap
 from .dummy_avatar import WaitDummy
@@ -31,9 +31,8 @@ class TestTurnManager(unittest.TestCase):
     def construct_turn_manager(self, avatars, locations):
         self.avatar_manager = DummyAvatarManager(avatars)
         self.game_state = GameState(InfiniteMap(), self.avatar_manager)
-        self.turn_manager = TurnManager(game_state=self.game_state,
-                                        end_turn_callback=lambda: None,
-                                        concurrent_turns=True)
+        self.turn_manager = ConcurrentTurnManager(game_state=self.game_state,
+                                                  end_turn_callback=lambda: None)
         for index, location in enumerate(locations):
             self.game_state.add_avatar(index, "", location)
         return self.turn_manager

--- a/aimmo-game/tests/simulation/test_turn_manager.py
+++ b/aimmo-game/tests/simulation/test_turn_manager.py
@@ -7,56 +7,120 @@ from simulation.location import Location
 from simulation.turn_manager import TurnManager
 
 from .maps import InfiniteMap
-from .dummy_avatar import DummyAvatarRunner
+from .dummy_avatar import WaitDummy
+from .dummy_avatar import MoveNorthDummy
+from .dummy_avatar import MoveEastDummy
+from .dummy_avatar import MoveSouthDummy
+from .dummy_avatar import MoveWestDummy
 from .dummy_avatar import DummyAvatarManager
 
 
-ORIGIN = Location(x=0, y=0)
+ORIGIN = Location(0, 0)
 
-RIGHT_OF_ORIGIN = Location(x=1, y=0)
-FIVE_RIGHT_OF_ORIGIN = Location(x=5, y=0)
+RIGHT_OF_ORIGIN = Location(1, 0)
+FIVE_RIGHT_OF_ORIGIN = Location(5, 0)
 
-ABOVE_ORIGIN = Location(x=0, y=1)
-FIVE_RIGHT_OF_ORIGIN_AND_ONE_ABOVE = Location(x=5, y=1)
+ABOVE_ORIGIN = Location(0, 1)
+FIVE_RIGHT_OF_ORIGIN_AND_ONE_ABOVE = Location(5, 1)
 
 
 class TestTurnManager(unittest.TestCase):
     def construct_default_avatar_appearance(self):
         return AvatarAppearance("#000", "#ddd", "#777", "#fff")
 
-    def construct_turn_manager(self, *avatars):
+    def construct_turn_manager(self, avatars, locations):
         self.avatar_manager = DummyAvatarManager(avatars)
         self.game_state = GameState(InfiniteMap(), self.avatar_manager)
         self.turn_manager = TurnManager(game_state=self.game_state,
                                         end_turn_callback=lambda: None,
                                         concurrent_turns=True)
+        for index, location in enumerate(locations):
+            self.game_state.add_avatar(index, "", location)
+        return self.turn_manager
+
+    def assert_at(self, avatar, location):
+        self.assertEqual(avatar.location, location)
+        cell = self.game_state.world_map.get_cell(location)
+        self.assertEqual(cell.avatar, avatar)
+
+    def get_avatar(self, player_id):
+        return self.avatar_manager.get_avatar(player_id)
+
+    def run_turn(self):
+        self.turn_manager.run_turn()
 
     def test_run_turn(self):
-        avatar = DummyAvatarRunner(ORIGIN, player_id=1)
-        self.construct_turn_manager(avatar)
-        self.turn_manager.run_turn()
-        self.assertEqual(avatar.location, RIGHT_OF_ORIGIN)
+        '''
+        Given:  > _
+        (1)
+        Expect: _ o
+        '''
+        self.construct_turn_manager([MoveEastDummy], [ORIGIN])
+        avatar = self.get_avatar(0)
+
+        self.assert_at(avatar, ORIGIN)
+        self.run_turn()
+        self.assert_at(avatar, RIGHT_OF_ORIGIN)
 
     def test_run_several_turns(self):
-        avatar = DummyAvatarRunner(ORIGIN, player_id=1)
-        self.construct_turn_manager(avatar)
-        [self.turn_manager.run_turn() for _ in range(5)]
+        '''
+        Given:  > _ _ _ _ _
+        (5)
+        Expect: _ _ _ _ _ o
+        '''
+        self.construct_turn_manager([MoveEastDummy], [ORIGIN])
+        avatar = self.get_avatar(0)
+
+        self.assertEqual(avatar.location, ORIGIN)
+        [self.run_turn() for _ in range(5)]
         self.assertEqual(avatar.location, FIVE_RIGHT_OF_ORIGIN)
 
     def test_run_several_turns_and_avatars(self):
-        avatar1 = DummyAvatarRunner(ORIGIN, player_id=1)
-        avatar2 = DummyAvatarRunner(ABOVE_ORIGIN, player_id=2)
-        self.construct_turn_manager(avatar1, avatar2)
-        [self.turn_manager.run_turn() for _ in range(5)]
-        self.assertEqual(avatar1.location, FIVE_RIGHT_OF_ORIGIN)
-        self.assertEqual(avatar2.location, FIVE_RIGHT_OF_ORIGIN_AND_ONE_ABOVE)
+        '''
+        Given:  > _ _ _ _ _
+                > _ _ _ _ _
+        (5)
+        Expect: _ _ _ _ _ o
+                _ _ _ _ _ o
+        '''
+        self.construct_turn_manager([MoveEastDummy, MoveEastDummy],
+                                    [ORIGIN,        ABOVE_ORIGIN])
+        avatar0 = self.get_avatar(0)
+        avatar1 = self.get_avatar(1)
 
-    def test_move_chain(self):
-        avatars = [DummyAvatarRunner(Location(x=x, y=0), player_id=x) for x in range(5)]
-        self.construct_turn_manager(*avatars)
-        self.turn_manager.run_turn()
-        [self.assertEqual(avatars[x].location, Location(x=x + 1, y=0)) for x in range(5)]
+        self.assert_at(avatar0, ORIGIN)
+        self.assert_at(avatar1, ABOVE_ORIGIN)
+        [self.run_turn() for _ in range(5)]
+        self.assert_at(avatar0, FIVE_RIGHT_OF_ORIGIN)
+        self.assert_at(avatar1, FIVE_RIGHT_OF_ORIGIN_AND_ONE_ABOVE)
 
+    def test_move_chain_succeeds(self):
+        '''
+        Given:  > > > > > _
+
+        Expect: _ o o o o o
+        '''
+        self.construct_turn_manager([MoveEastDummy for _ in range(5)],
+                                    [Location(x, 0) for x in range(5)])
+        avatars = [self.get_avatar(i) for i in range(5)]
+
+        [self.assert_at(avatars[x], Location(x, 0)) for x in range(5)]
+        self.run_turn()
+        [self.assert_at(avatars[4-x], Location(4-x + 1, 0)) for x in range(5)]
+
+    def test_move_chain_fails_occupied(self):
+        '''
+        Given:  > > x _
+
+        Expect: x x x _
+        '''
+        self.construct_turn_manager([MoveEastDummy, MoveEastDummy, WaitDummy],
+                                    [Location(x, 0) for x in range(3)])
+        avatars = [self.get_avatar(i) for i in range(3)]
+
+        [self.assert_at(avatars[x], Location(x, 0)) for x in range(3)]
+        self.run_turn()
+        [self.assert_at(avatars[x], Location(x, 0)) for x in range(3)]
 
 if __name__ == '__main__':
     unittest.main()

--- a/aimmo-game/tests/simulation/test_turn_manager.py
+++ b/aimmo-game/tests/simulation/test_turn_manager.py
@@ -1,13 +1,15 @@
 from __future__ import absolute_import
 import unittest
 
-from simulation.avatar.avatar_manager import AvatarManager
-from simulation.location import Location
-from simulation.turn_manager import TurnManager
-from .maps import InfiniteMap
-from .dummy_avatar import DummyAvatarRunner
 from simulation.avatar.avatar_appearance import AvatarAppearance
 from simulation.game_state import GameState
+from simulation.location import Location
+from simulation.turn_manager import TurnManager
+
+from .maps import InfiniteMap
+from .dummy_avatar import DummyAvatarRunner
+from .dummy_avatar import DummyAvatarManager
+
 
 ORIGIN = Location(x=0, y=0)
 
@@ -18,15 +20,16 @@ ABOVE_ORIGIN = Location(x=0, y=1)
 FIVE_RIGHT_OF_ORIGIN_AND_ONE_ABOVE = Location(x=5, y=1)
 
 
-@unittest.expectedFailure
 class TestTurnManager(unittest.TestCase):
     def construct_default_avatar_appearance(self):
         return AvatarAppearance("#000", "#ddd", "#777", "#fff")
 
     def construct_turn_manager(self, *avatars):
-        self.avatar_manager = AvatarManager(avatars)
+        self.avatar_manager = DummyAvatarManager(avatars)
         self.game_state = GameState(InfiniteMap(), self.avatar_manager)
-        self.turn_manager = TurnManager(self.game_state)
+        self.turn_manager = TurnManager(game_state=self.game_state,
+                                        end_turn_callback=lambda: None,
+                                        concurrent_turns=True)
 
     def test_run_turn(self):
         avatar = DummyAvatarRunner(ORIGIN, player_id=1)
@@ -47,6 +50,13 @@ class TestTurnManager(unittest.TestCase):
         [self.turn_manager.run_turn() for _ in range(5)]
         self.assertEqual(avatar1.location, FIVE_RIGHT_OF_ORIGIN)
         self.assertEqual(avatar2.location, FIVE_RIGHT_OF_ORIGIN_AND_ONE_ABOVE)
+
+    def test_move_chain(self):
+        avatars = [DummyAvatarRunner(Location(x=x, y=0), player_id=x) for x in range(5)]
+        self.construct_turn_manager(*avatars)
+        self.turn_manager.run_turn()
+        [self.assertEqual(avatars[x].location, Location(x=x + 1, y=0)) for x in range(5)]
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/aimmo-game/tests/simulation/test_turn_manager.py
+++ b/aimmo-game/tests/simulation/test_turn_manager.py
@@ -106,7 +106,7 @@ class TestTurnManager(unittest.TestCase):
 
         [self.assert_at(avatars[x], Location(x, 0)) for x in range(5)]
         self.run_turn()
-        [self.assert_at(avatars[4-x], Location(4-x + 1, 0)) for x in range(5)]
+        [self.assert_at(avatars[x], Location(x + 1, 0)) for x in range(5)]
 
     def test_move_chain_fails_occupied(self):
         '''
@@ -121,6 +121,62 @@ class TestTurnManager(unittest.TestCase):
         [self.assert_at(avatars[x], Location(x, 0)) for x in range(3)]
         self.run_turn()
         [self.assert_at(avatars[x], Location(x, 0)) for x in range(3)]
+
+    def test_move_chain_fails_collision(self):
+        '''
+        Given:  > > > _ <
+        (1)
+        Expect: x x x _ x
+        '''
+        locations = [Location(0, 0), Location(1, 0), Location(2, 0), Location(4, 0)]
+        self.construct_turn_manager(
+            [MoveEastDummy, MoveEastDummy, MoveEastDummy, MoveWestDummy],
+            locations)
+        avatars = [self.get_avatar(i) for i in range(4)]
+
+        [self.assert_at(avatars[i], locations[i]) for i in range(4)]
+        self.run_turn()
+        [self.assert_at(avatars[i], locations[i]) for i in range(4)]
+
+    def test_move_chain_fails_cycle(self):
+        '''
+        Given:  > v
+                ^ <
+        (1)
+        Expect: x x
+                x x
+        '''
+        locations = [Location(0, 1), Location(1, 1), Location(1, 0), Location(0, 0)]
+        self.construct_turn_manager(
+            [MoveEastDummy, MoveSouthDummy, MoveWestDummy, MoveNorthDummy],
+            locations)
+        avatars = [self.get_avatar(i) for i in range(4)]
+
+        [self.assert_at(avatars[i], locations[i]) for i in range(4)]
+        self.run_turn()
+        [self.assert_at(avatars[i], locations[i]) for i in range(4)]
+
+    def test_move_chain_fails_spiral(self):
+        '''
+        Given:  > > v
+                  ^ <
+        (1)
+        Expect: x x x
+                  x x
+        '''
+        locations = [Location(0, 1),
+                     Location(1, 1),
+                     Location(2, 1),
+                     Location(2, 0),
+                     Location(1, 0)]
+        self.construct_turn_manager(
+            [MoveEastDummy, MoveEastDummy, MoveSouthDummy, MoveWestDummy, MoveNorthDummy],
+            locations)
+        avatars = [self.get_avatar(i) for i in range(5)]
+
+        [self.assert_at(avatars[i], locations[i]) for i in range(5)]
+        self.run_turn()
+        [self.assert_at(avatars[i], locations[i]) for i in range(5)]
 
 if __name__ == '__main__':
     unittest.main()

--- a/aimmo-game/tests/simulation/test_worker_manager.py
+++ b/aimmo-game/tests/simulation/test_worker_manager.py
@@ -78,7 +78,7 @@ class TestWorkerManager(unittest.TestCase):
             self.worker_manager.update()
         self.assertEqual(len(self.worker_manager.final_workers), 3)
         for i in xrange(3):
-            self.assertIn(i, self.game_state.avatar_manager.avatarsById)
+            self.assertIn(i, self.game_state.avatar_manager.avatars_by_id)
             self.assertIn(i, self.worker_manager.final_workers)
             self.assertEqual(self.worker_manager.get_code(i), 'code for %s' % i)
 
@@ -92,7 +92,7 @@ class TestWorkerManager(unittest.TestCase):
 
         for i in xrange(4):
             self.assertIn(i, self.worker_manager.final_workers)
-            self.assertIn(i, self.game_state.avatar_manager.avatarsById)
+            self.assertIn(i, self.game_state.avatar_manager.avatars_by_id)
 
         for i in (1, 3):
             self.assertEqual(self.worker_manager.get_code(i), 'code for %s' % i)
@@ -108,4 +108,4 @@ class TestWorkerManager(unittest.TestCase):
             del mocker.value['main']['users'][1]
             self.worker_manager.update()
         self.assertNotIn(1, self.worker_manager.final_workers)
-        self.assertNotIn(1, self.game_state.avatar_manager.avatarsById)
+        self.assertNotIn(1, self.game_state.avatar_manager.avatars_by_id)

--- a/aimmo-game/tests/simulation/test_worker_manager.py
+++ b/aimmo-game/tests/simulation/test_worker_manager.py
@@ -1,11 +1,14 @@
 from __future__ import absolute_import
+
 from httmock import HTTMock
 from json import dumps
+import unittest
+
 from simulation.avatar.avatar_manager import AvatarManager
 from simulation.game_state import GameState
-from .maps import InfiniteMap
 from simulation.worker_manager import WorkerManager
-import unittest
+
+from .maps import InfiniteMap
 
 
 class ConcreteWorkerManager(WorkerManager):

--- a/aimmo-game/tests/simulation/test_world_map.py
+++ b/aimmo-game/tests/simulation/test_world_map.py
@@ -1,10 +1,14 @@
 from __future__ import absolute_import
+
 from string import ascii_uppercase
+from unittest import TestCase
+
 from simulation import world_map
 from simulation.location import Location
-from .maps import MockCell
 from simulation.world_map import Cell, WorldMap
-from unittest import TestCase
+
+from .maps import MockCell
+from .dummy_avatar import DummyAvatarRunner
 
 
 class Serialiser(object):
@@ -296,7 +300,7 @@ class TestWorldMap(TestCase):
 
     def test_cannot_move_to_habited_cell(self):
         target = Location(0, 0)
-        cell = MockCell(target, avatar=True)
+        cell = MockCell(target, avatar=DummyAvatarRunner(target, 0))
         map = WorldMap([[cell]])
         target = Location(0, 0)
         self.assertFalse(map.can_move_to(target))

--- a/aimmo-game/tests/simulation/test_world_map.py
+++ b/aimmo-game/tests/simulation/test_world_map.py
@@ -8,7 +8,7 @@ from simulation.location import Location
 from simulation.world_map import Cell, WorldMap
 
 from .maps import MockCell
-from .dummy_avatar import DummyAvatarRunner
+from .dummy_avatar import DummyAvatar
 
 
 class Serialiser(object):
@@ -300,7 +300,7 @@ class TestWorldMap(TestCase):
 
     def test_cannot_move_to_habited_cell(self):
         target = Location(0, 0)
-        cell = MockCell(target, avatar=DummyAvatarRunner(target, 0))
+        cell = MockCell(target, avatar=DummyAvatar(target, 0))
         map = WorldMap([[cell]])
         target = Location(0, 0)
         self.assertFalse(map.can_move_to(target))

--- a/aimmo-game/tests/test_service.py
+++ b/aimmo-game/tests/test_service.py
@@ -4,7 +4,7 @@ from simulation.game_state import GameState
 from simulation.location import Location
 from .simulation.dummy_avatar import DummyAvatarRunner
 from .simulation.test_world_map import MockCell
-from simulation.turn_manager import world_state_provider
+from simulation.turn_manager import state_provider
 from simulation.world_map import WorldMap
 from unittest import TestCase
 
@@ -35,7 +35,7 @@ class TestService(TestCase):
         ]
         grid = [[MockCell(Location(x, y), **CELLS[x][y])
                  for y in xrange(3)] for x in xrange(2)]
-        world_state_provider.set_world(GameState(WorldMap(grid), SimpleAvatarManager()))
+        state_provider.set_world(GameState(WorldMap(grid), SimpleAvatarManager()))
         return service.get_world_state()
 
     def test_player_dict(self):

--- a/aimmo-game/tests/test_service.py
+++ b/aimmo-game/tests/test_service.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import service
 from simulation.game_state import GameState
 from simulation.location import Location
-from .simulation.dummy_avatar import DummyAvatarRunner
+from .simulation.dummy_avatar import MoveEastDummy
 from .simulation.test_world_map import MockCell
 from simulation.turn_manager import state_provider
 from simulation.world_map import WorldMap
@@ -10,7 +10,7 @@ from unittest import TestCase
 
 
 class SimpleAvatarManager(object):
-    avatars = [DummyAvatarRunner(Location(0, 1), 1)]
+    avatars = [MoveEastDummy(1, Location(0, 1))]
 
 
 class TestService(TestCase):


### PR DESCRIPTION
- `run_turn` now performs each worker request in a new thread
- actions are registered on the world map before they are applied
- once all actions are registered, actions are applied in this order:
    - wait actions
    - attack actions
    - move actions
- avatars may be attacked in both their current location and their new location
- if two or more avatars attempt to move to the same location, they all fail