### PR TITLE
Add better error handling and logging

### DIFF
--- a/aimmo-game-worker/initialise.py
+++ b/aimmo-game-worker/initialise.py
@@ -4,10 +4,15 @@ import os
 import sys
 import json
 import requests
+import logging
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def main(args, url):
     data_dir = args[1]
+    LOGGER.debug('Data dir is %s', data_dir)
 
     data = requests.get(url).json()
 
@@ -20,4 +25,5 @@ def main(args, url):
         avatar_file.write(code)
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
     main(sys.argv, url=os.environ['DATA_URL'])

--- a/aimmo-game-worker/service.py
+++ b/aimmo-game-worker/service.py
@@ -11,16 +11,20 @@ from simulation.avatar_state import AvatarState
 from avatar import Avatar
 
 app = flask.Flask(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 @app.route('/turn/', methods=['POST'])
 def process_turn():
+    LOGGER.info('Calculating action')
     data = flask.request.get_json()
 
     world_map = WorldMap(**data['world_map'])
     avatar_state = AvatarState(**data['avatar_state'])
 
+    LOGGER.debug('Calling user code')
     action = avatar.handle_turn(avatar_state, world_map)
+    LOGGER.debug('Done')
 
     return flask.jsonify(action=action.serialise())
 

--- a/aimmo-game/simulation/turn_manager.py
+++ b/aimmo-game/simulation/turn_manager.py
@@ -1,7 +1,5 @@
 import logging
-import requests
 import time
-from Queue import PriorityQueue
 from threading import Lock
 from threading import Thread
 
@@ -64,13 +62,16 @@ class TurnManager(Thread):
 
     def run(self):
         while True:
-            self.run_turn()
+            try:
+                self.run_turn()
 
-            with state_provider as game_state:
-                game_state.update_environment()
-                game_state.world_map.apply_score()
+                with state_provider as game_state:
+                    game_state.update_environment()
+                    game_state.world_map.apply_score()
 
-            self.end_turn_callback()
+                self.end_turn_callback()
+            except Exception:
+                LOGGER.exception('Error while running turn')
             time.sleep(0.5)
 
 


### PR DESCRIPTION
* If there is a crash during the `TurnManager` main loop log it but keep running (previously the exception was uncaught which means the game would crash).
* Add logging in workers.
* Wait for workers to be running before trying to get their IP. (Otherwise causes crash.)