### PR TITLE
Replace Ingress with a reverse proxy

### DIFF
--- a/aimmo-game-creator/service.py
+++ b/aimmo-game-creator/service.py
@@ -3,7 +3,7 @@
 import logging
 from pykube import HTTPClient
 from pykube import KubeConfig
-from pykube import Ingress, ReplicationController, Service
+from pykube import ReplicationController, Service
 import time
 
 LOGGER = logging.getLogger(__name__)
@@ -132,39 +132,6 @@ def maintain_games(api, games):
             if game_id not in current_game_names:
                 LOGGER.info("Creating game %s", game_id)
                 creation_callback(api, game_id, game_config)
-
-    ingress = Ingress(
-        api,
-        {
-            'apiVersion': 'extensions/v1beta1',
-            'kind': 'Ingress',
-            'metadata': {
-                'name': 'game',
-            },
-            'spec': {
-                'rules': [
-                    {
-                        'host': 'staging.aimmo.codeforlife.education',
-                        'http': {
-                            'paths': [
-                                {
-                                    'path': "/game/%s/*" % name,
-                                    'backend': {
-                                        'serviceName': "game-%s" % name,
-                                        'servicePort': 80,
-                                    },
-                                } for name in games.keys()
-                            ],
-                        },
-                    },
-                ],
-            },
-        },
-    )
-    if ingress.exists():
-        ingress.update()
-    else:
-        ingress.create()
 
 
 def main():

--- a/aimmo-reverse-proxy/Dockerfile
+++ b/aimmo-reverse-proxy/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/aimmo-reverse-proxy/deploy-aimmo-reverse-proxy.yaml
+++ b/aimmo-reverse-proxy/deploy-aimmo-reverse-proxy.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: aimmo-reverse-proxy
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: aimmo-reverse-proxy
+    spec:
+      containers:
+      - name: aimmo-reverse-proxy
+        image: ocadotechnology/aimmo-reverse-proxy:latest
+        ports:
+        - containerPort: 80

--- a/aimmo-reverse-proxy/ingress.yaml
+++ b/aimmo-reverse-proxy/ingress.yaml
@@ -1,0 +1,8 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: aimmo-ingress
+spec:
+  backend:
+    serviceName: aimmo-reverse-proxy
+    servicePort: 80

--- a/aimmo-reverse-proxy/nginx.conf
+++ b/aimmo-reverse-proxy/nginx.conf
@@ -1,0 +1,13 @@
+
+http {
+    resolver 10.0.0.10;
+    server {
+        listen 80;
+        location ~^/game/([a-zA-Z]+)/? {
+            proxy_pass "http://game-$1.default.svc.cluster.local/";
+        }
+    }
+}
+
+events {
+}

--- a/aimmo-reverse-proxy/service-aimmo-reverse-proxy.yaml
+++ b/aimmo-reverse-proxy/service-aimmo-reverse-proxy.yaml
@@ -1,0 +1,11 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: aimmo-reverse-proxy
+spec:
+  selector:
+    app: aimmo-reverse-proxy
+  ports:
+  - protocol: TCP
+    port: 80
+  type: NodePort


### PR DESCRIPTION
* Run a nginx pod which does the same job ingress was doing but use the Kubernetes DNS instead of updating with aimmo-game-creator.
* Add this pod to a static ingress.

Config that will need updating:
* Add the new image to Docker Hub.
* Launch the new pod in the update script.
* Update the DNS alias for staging.aimmo.codeforlife.education to point to the new ingress IP