### PR TITLE
Enable eventlet even during testing

### DIFF
--- a/aimmo-game/service.py
+++ b/aimmo-game/service.py
@@ -3,10 +3,8 @@ import logging
 import os
 import sys
 
-# If we monkey patch during testing then Django fails to create a DB enironment
-if __name__ == '__main__':
-    import eventlet
-    eventlet.monkey_patch()
+import eventlet
+eventlet.monkey_patch()
 
 import flask
 from flask_socketio import SocketIO, emit


### PR DESCRIPTION
As not testing via django-setuptest anymore the catch for eventlet monkey patching can be removed.