### PR TITLE
fix #163 and other __ne__ issues

### DIFF
--- a/aimmo-game-worker/simulation/location.py
+++ b/aimmo-game-worker/simulation/location.py
@@ -1,5 +1,4 @@
 class Location(object):
-
     def __init__(self, x, y):
         self.x = x
         self.y = y
@@ -15,6 +14,9 @@ class Location(object):
 
     def __eq__(self, other):
         return self.x == other.x and self.y == other.y
+
+    def __ne__(self, other):
+        return not self == other
 
     def __hash__(self):
         return hash((self.x, self.y))

--- a/aimmo-game-worker/simulation/world_map.py
+++ b/aimmo-game-worker/simulation/world_map.py
@@ -26,6 +26,9 @@ class Cell(object):
     def __eq__(self, other):
         return self.location == other.location
 
+    def __ne__(self, other):
+        return not self == other
+
 
 class WorldMap(object):
 

--- a/aimmo-game/simulation/location.py
+++ b/aimmo-game/simulation/location.py
@@ -15,8 +15,11 @@ class Location(object):
     def __eq__(self, other):
         return self.x == other.x and self.y == other.y
 
+    def __ne__(self, other):
+        return not self == other
+
     def __hash__(self):
-        return hash(self.x) ^ hash(self.y)
+        return hash((self.x, self.y))
 
     def serialise(self):
         return {'x': self.x, 'y': self.y}

--- a/aimmo-game/simulation/world_map.py
+++ b/aimmo-game/simulation/world_map.py
@@ -1,6 +1,5 @@
 import math
 import random
-
 from logging import getLogger
 
 import map_generator
@@ -31,6 +30,9 @@ class Cell(object):
 
     def __eq__(self, other):
         return self.location == other.location
+
+    def __ne__(self, other):
+        return not self == other
 
     def __hash__(self):
         return hash(self.location)

--- a/aimmo-game/tests/test_simulation/test_game_state.py
+++ b/aimmo-game/tests/test_simulation/test_game_state.py
@@ -36,7 +36,7 @@ class TestGameState(TestCase):
         game_state.remove_avatar(1)
 
         self.assertNotIn(1, manager.avatars_by_id)
-        self.assertEqual(world_map.get_cell((0, 0)).avatar, None)
+        self.assertEqual(world_map.get_cell(Location(0, 0)).avatar, None)
 
         self.assertTrue(manager.avatars_by_id[2].marked)
         self.assertTrue(world_map.get_cell(Location(1, 1)).avatar.marked)

--- a/aimmo-game/tests/test_simulation/test_location.py
+++ b/aimmo-game/tests/test_simulation/test_location.py
@@ -10,16 +10,19 @@ class TestLocation(TestCase):
         loc_1 = Location(3, 3)
         loc_2 = Location(3, 3)
         self.assertEqual(loc_1, loc_2)
+        self.assertFalse(loc_1 != loc_2)
 
     def test_x_not_equal(self):
         loc_1 = Location(3, 3)
         loc_2 = Location(4, 3)
         self.assertNotEqual(loc_1, loc_2)
+        self.assertFalse(loc_1 == loc_2)
 
     def test_y_not_equal(self):
         loc_1 = Location(4, 4)
         loc_2 = Location(4, 3)
         self.assertNotEqual(loc_1, loc_2)
+        self.assertFalse(loc_1 == loc_2)
 
     def test_add(self):
         loc_1 = Location(1, 2)

--- a/aimmo-game/tests/test_simulation/test_map_generator.py
+++ b/aimmo-game/tests/test_simulation/test_map_generator.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import random
 import unittest
 
 from simulation import map_generator
@@ -65,6 +66,7 @@ class TestHelperFunctions(unittest.TestCase):
 
 class _BaseGeneratorTestCase(unittest.TestCase):
     def get_game_state(self, **kwargs):
+        random.seed(0)
         settings = {
             'START_WIDTH': 3,
             'START_HEIGHT': 4,
@@ -81,14 +83,14 @@ class TestMainGenerator(_BaseGeneratorTestCase):
     GENERATOR_CLASS = map_generator.Main
 
     def test_map_dimensions(self):
-        m = self.get_map()
-        grid = list(m.all_cells())
-        self.assertEqual(len(set(grid)), len(grid), "Repeats in list")
-        for c in grid:
-            self.assertLessEqual(c.location.x, 1)
-            self.assertLessEqual(c.location.y, 2)
-            self.assertGreaterEqual(c.location.x, -1)
-            self.assertGreaterEqual(c.location.y, -1)
+            m = self.get_map()
+            grid = list(m.all_cells())
+            self.assertEqual(len(set(grid)), len(grid), "Repeats in list")
+            for c in grid:
+                self.assertLessEqual(c.location.x, 1)
+                self.assertLessEqual(c.location.y, 2)
+                self.assertGreaterEqual(c.location.x, -1)
+                self.assertGreaterEqual(c.location.y, -1)
 
     def test_obstable_ratio(self):
         m = self.get_map(OBSTACLE_RATIO=0)


### PR DESCRIPTION
Location implements __eq__, but not __ne__, which means if comparing two locations that are the same `a == b` returns True, and `a != b` also returns True (because the default is object identity, rather than the negation of the __eq__ method. Sigh.

Fixed by implementing __ne__.

Also made map_generator tests deterministic (`random.seed(0)`).