### PR TITLE
Minimum Product: World map ported to python3.

### DIFF
--- a/aimmo-game/simulation/world_map.py
+++ b/aimmo-game/simulation/world_map.py
@@ -2,7 +2,6 @@ import math
 import random
 from logging import getLogger
 
-from simulation.world_state import MapFeature
 from simulation.pickups import ALL_PICKUPS
 from simulation.location import Location
 from simulation.maps.cell import Cell
@@ -44,14 +43,23 @@ class WorldMap(object):
 
         (min_x, max_x, min_y, max_y) = WorldMap._min_max_from_dimensions(height, width)
         grid = {}
-        for x in xrange(min_x, max_x + 1):
-            for y in xrange(min_y, max_y + 1):
+        for x in range(min_x, max_x + 1):
+            for y in range(min_y, max_y + 1):
                 location = Location(x, y)
                 grid[location] = Cell(location)
         return cls(grid, new_settings)
 
     def all_cells(self):
-        return self.grid.itervalues()
+        '''
+        Written to support both python3 and python2. itervalues() became obsolete
+        in py3 and values() returns dictionary views, which are iterators.
+        :return: Iterator (dictionary or iterator) of all cells in the grid.
+        '''
+        try:
+            values = self.grid.itervalues()
+        except AttributeError:
+            values = self.grid.values()
+        return values
 
     def potential_spawn_locations(self):
         return (c for c in self.all_cells()
@@ -139,11 +147,11 @@ class WorldMap(object):
         self._add_horizontal_layer(self.max_y() + 1)
 
     def _add_vertical_layer(self, x):
-        for y in xrange(self.min_y(), self.max_y() + 1):
+        for y in range(self.min_y(), self.max_y() + 1):
             self.grid[Location(x, y)] = Cell(Location(x, y))
 
     def _add_horizontal_layer(self, y):
-        for x in xrange(self.min_x(), self.max_x() + 1):
+        for x in range(self.min_x(), self.max_x() + 1):
             self.grid[Location(x, y)] = Cell(Location(x, y))
 
     def _add_pickups(self, num_avatars):
@@ -211,8 +219,8 @@ class WorldMap(object):
 
     def __iter__(self):
         return ((self.get_cell(Location(x, y))
-                for y in xrange(self.min_y(), self.max_y() + 1))
-                for x in xrange(self.min_x(), self.max_x() + 1))
+                for y in range(self.min_y(), self.max_y() + 1))
+                for x in range(self.min_x(), self.max_x() + 1))
 
 
 def world_map_static_spawn_decorator(world_map, spawn_location):

--- a/aimmo-game/tests/test_simulation/test_world_map.py
+++ b/aimmo-game/tests/test_simulation/test_world_map.py
@@ -83,7 +83,7 @@ class TestWorldMap(TestCase):
     def _generate_grid(self, columns=2, rows=2):
         alphabet = iter(ascii_uppercase)
         grid = {Location(x, y): MockCell(Location(x, y), name=next(alphabet))
-                for x in xrange(columns) for y in xrange(rows)}
+                for x in range(columns) for y in range(rows)}
         return grid
 
     def _grid_from_list(self, in_list):
@@ -110,6 +110,7 @@ class TestWorldMap(TestCase):
         self.assertGridSize(map, 5, 2)
 
     def test_all_cells(self):
+        # Try block when python2 is used.
         map = WorldMap(self._generate_grid(), self.settings)
         cell_names = [c.name for c in map.all_cells()]
         self.assertIn('A', cell_names)
@@ -117,6 +118,7 @@ class TestWorldMap(TestCase):
         self.assertIn('C', cell_names)
         self.assertIn('D', cell_names)
         self.assertEqual(len(cell_names), 4)
+
 
     def test_potential_spawns(self):
         spawnable1 = MockCell()
@@ -305,7 +307,7 @@ class TestWorldMapWithOriginCentre(TestWorldMap):
     def _generate_grid(self, columns=2, rows=2):
         alphabet = iter(ascii_uppercase)
         grid = {Location(x, y): MockCell(Location(x, y), name=next(alphabet))
-                for x in xrange(-int_ceil(columns/2.0)+1, int_floor(columns/2.0)+1) for y in xrange(-int_ceil(rows/2.0)+1, int_floor(rows/2.0)+1)}
+                for x in range(-int_ceil(columns/2.0)+1, int_floor(columns/2.0)+1) for y in range(-int_ceil(rows/2.0)+1, int_floor(rows/2.0)+1)}
 
         return grid
 
@@ -328,5 +330,5 @@ class TestWorldMapWithOriginCentre(TestWorldMap):
 class TestStaticSpawnDecorator(TestCase):
     def test_spawn_is_static(self):
         decorated_map = world_map_static_spawn_decorator(WorldMap({}, {}), Location(3, 7))
-        for _ in xrange(5):
+        for _ in range(5):
             self.assertEqual(decorated_map.get_random_spawn_location(), Location(3, 7))


### PR DESCRIPTION
Ported `world_map` and `test_world_map` to python3, ie:

- `xrange` is now replaced is `range`.
- `try` and `except` used in instances where `itervalues()` is used. This way I can allow for both versions to run the code.