### PR TITLE
Pickup Tests

### DIFF
--- a/aimmo-game/simulation/pickups.py
+++ b/aimmo-game/simulation/pickups.py
@@ -1,7 +1,6 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
 import effects
 
-
 class _Pickup(object):
     __metaclass__ = ABCMeta
 
@@ -29,8 +28,15 @@ class _Pickup(object):
 
 class HealthPickup(_Pickup):
     def __init__(self, cell, health_restored=3):
-        super(HealthPickup, self).__init__(cell)
-        self.health_restored = health_restored
+        # Round the value to the nearest integer.
+        health_restored = int(round(health_restored))
+
+        # Check if the value provided is legal.
+        if 0 < health_restored <= 100:
+            super(HealthPickup, self).__init__(cell)
+            self.health_restored = health_restored
+        else:
+            raise ValueError("Health Restored has to be within 0-100 range!")
 
     def __repr__(self):
         return 'HealthPickup(health_restored={})'.format(self.health_restored)
@@ -43,6 +49,10 @@ class HealthPickup(_Pickup):
 
     def _apply(self, avatar):
         avatar.health += self.health_restored
+
+        # Make sure the health is capped at 100.
+        if avatar.health > 100:
+            avatar.health = 100
 
 
 class _PickupEffect(_Pickup):
@@ -73,9 +83,9 @@ class InvulnerabilityPickup(_PickupEffect):
 class DamagePickup(_PickupEffect):
     EFFECT = effects.DamagePickupEffect
 
-    def __init__(self, *args):
-        super(DamagePickup, self).__init__(*args)
-        self.damage_boost = 5
+    def __init__(self, cell, damage_boost=5):
+        super(DamagePickup, self).__init__(cell)
+        self.damage_boost = damage_boost
         self.params.append(self.damage_boost)
 
     def __repr__(self):

--- a/aimmo-game/tests/test_simulation/test_pickups.py
+++ b/aimmo-game/tests/test_simulation/test_pickups.py
@@ -17,6 +17,9 @@ class _BaseCases(object):
             self.cell = MockCell()
             self.pickup = self.pickup_class(self.cell)
 
+        def set_custom_pickup(self, *args):
+            self.pickup = self.pickup_class(self.cell, *args)
+
         def apply_pickup(self):
             self.pickup.apply(self.avatar)
 
@@ -44,6 +47,10 @@ class _BaseCases(object):
 class TestHealthPickup(_BaseCases.BasePickupTestCase):
     pickup_class = pickups.HealthPickup
 
+    def test_invulnerability_is_applied(self):
+        self.apply_pickup()
+        self.assertIsInstance(self.pickup, pickups.HealthPickup)
+
     def test_health_increases(self):
         self.apply_pickup()
         self.assertEqual(self.avatar.health, 8)
@@ -51,10 +58,52 @@ class TestHealthPickup(_BaseCases.BasePickupTestCase):
     def test_serialise(self):
         self.assertEqual(self.pickup.serialise(), {'type': 'health', 'health_restored': 3})
 
+    def test_given_custom_health_pickup_increase_health_increases(self):
+        # Test 1 - increase of 5
+        self.assertEqual(self.avatar.health, 5)
+        self.set_custom_pickup(5)
+
+        self.apply_pickup()
+
+        self.assertEqual(self.avatar.health, 10)
+
+        # Test 2 - increase of 50
+        self.avatar.health = 10
+        self.set_custom_pickup(50)
+
+        self.apply_pickup()
+
+        self.assertEqual(self.avatar.health, 60)
+
+    def test_health_argument_raises_exception_when_health_exceeded(self):
+        self.assertRaises(ValueError, self.set_custom_pickup, 150)
+
+    def test_health_argument_raises_exception_when_health_useless(self):
+        self.assertRaises(ValueError, self.set_custom_pickup, 0)
+
+    def test_health_argument_raises_exception_when_health_under(self):
+        self.assertRaises(ValueError, self.set_custom_pickup, -50)
+
+    def test_health_cannot_be_greater_than_100(self):
+        self.assertEqual(self.avatar.health, 5)
+        self.set_custom_pickup(100)
+
+        self.apply_pickup()
+
+        self.assertEqual(self.avatar.health, 100)
+
+    def test_health_rounding_up_to_nearest_int(self):
+        self.set_custom_pickup(9.5)
+        self.assertEqual(self.pickup.health_restored, 10)
+
 
 class TestInvulnerabilityPickup(_BaseCases.BasePickupEffectTestCase):
     pickup_class = pickups.InvulnerabilityPickup
     effect_class = effects.InvulnerabilityPickupEffect
+
+    def test_invulnerability_is_applied(self):
+        self.apply_pickup()
+        self.assertIsInstance(self.pickup, pickups.InvulnerabilityPickup)
 
     def test_serialise(self):
         self.assertEqual(self.pickup.serialise(), {'type': 'invulnerability'})
@@ -64,5 +113,18 @@ class TestDamagePickup(_BaseCases.BasePickupEffectTestCase):
     pickup_class = pickups.DamagePickup
     effect_class = effects.DamagePickupEffect
 
-    def test_serialise(self):
+    def test_damagepickup_is_applied(self):
+        self.apply_pickup()
+        self.assertIsInstance(self.pickup, pickups.DamagePickup)
+
+    def test_damagepickup_default_params(self):
+        self.assertEqual(len(self.avatar.effects), 0)
+        self.apply_pickup()
+        self.assertEqual(len(self.avatar.effects), 1)
+
+    def test_serialise_default(self):
         self.assertEqual(self.pickup.serialise(), {'type': 'damage', 'damage_boost': 5})
+
+    def test_serialise_custom(self):
+        self.set_custom_pickup(20)
+        self.assertEqual(self.pickup.serialise(), {'type': 'damage', 'damage_boost': 20})


### PR DESCRIPTION
Initial dig at writing more extensive unit pickup tests. Coverage of the file was fine but they clearly weren't tested well enough. I'm new to tests so criticize as much as you can :P

- `HealthPickup` has now certain constraints. It can't be equal to or less than 0, and can't be greater than 100.
- If the pickup added to the avatar health will be greater than 100, cap it at 100hp.
- DamagePickup can be now specified with the custom damage boost.
- Pickups are more testable. You can make use of `set_custom_pickup` to add your own params as opposed to using only default ones.
- Extra tests.

Please test extensively before approving. We **don't** have integration tests anymore. Use the manual test plan to get an idea of things that need to be checked. 