### PR TITLE
Add stale.yml to indicate integration with the stale app

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,13 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,7 +3,7 @@ daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 14
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
Adds [stale app](https://probot.github.io/apps/stale/) settings to our project.

We have agreed on the following:

- **Two months of inactivity to review** stale issues.
- **Two weeks** of inactivity after request for review for issue to be marked as **stale** and closed.
- **Comment is added**