### PR TITLE
Logic to distinguish current avatar ID serverside

### DIFF
--- a/aimmo-game-creator/rc-aimmo-game-creator.yaml
+++ b/aimmo-game-creator/rc-aimmo-game-creator.yaml
@@ -26,6 +26,6 @@ spec:
         - name: IMAGE_SUFFIX
           value: latest
         - name: GAME_API_URL
-          value: REPLACE_ME/api/games
+          value: REPLACE_ME
         - name: WORKER_MANAGER
           value: kubernetes

--- a/aimmo-game-creator/tests/test_aimmo_game_creator_yaml.py
+++ b/aimmo-game-creator/tests/test_aimmo_game_creator_yaml.py
@@ -20,4 +20,4 @@ class TestAimmoGameCreatorYaml(TestCase):
         Ensures the yaml template contains the correct string to be replaced.
         """
         self.assertEqual(self.yaml_dict['spec']['template']['spec']['containers'][0]['env'][1]['value'],
-                         "REPLACE_ME/api/games")
+                         "REPLACE_ME")

--- a/aimmo-game-creator/worker_manager.py
+++ b/aimmo-game-creator/worker_manager.py
@@ -92,7 +92,7 @@ class WorkerManager(object):
 
         # Spawn worker
         LOGGER.info("Spawning worker for game %s" % game_data['name'])
-        game_data['GAME_API_URL'] = '{}{}'.format(self.games_url, game_id)
+        game_data['GAME_API_URL'] = '{}{}/'.format(self.games_url, game_id)
         self.create_worker(game_id, game_data)
 
     def _parallel_map(self, func, *iterable_args):

--- a/aimmo-game-creator/worker_manager.py
+++ b/aimmo-game-creator/worker_manager.py
@@ -92,7 +92,7 @@ class WorkerManager(object):
 
         # Spawn worker
         LOGGER.info("Spawning worker for game %s" % game_data['name'])
-        game_data['GAME_API_URL'] = '{}{}/'.format(self.games_url, game_id)
+        game_data['GAME_API_URL'] = '{}{}'.format(self.games_url, game_id)
         self.create_worker(game_id, game_data)
 
     def _parallel_map(self, func, *iterable_args):

--- a/aimmo_runner/minikube.py
+++ b/aimmo_runner/minikube.py
@@ -49,7 +49,7 @@ def create_ingress_yaml():
 def create_creator_yaml():
     orig_path = os.path.join(BASE_DIR, 'aimmo-game-creator', 'rc-aimmo-game-creator.yaml')
     with open(orig_path) as orig_file:
-        content = yaml.safe_load(orig_file.read().replace('latest', 'test').replace('REPLACE_ME', 'http://%s:8000/players' % get_ip()))
+        content = yaml.safe_load(orig_file.read().replace('latest', 'test').replace('REPLACE_ME', 'http://%s:8000/players/api/games/' % get_ip()))
     return content
 
 

--- a/aimmo_runner/tests/test_minikube_runner.py
+++ b/aimmo_runner/tests/test_minikube_runner.py
@@ -16,4 +16,4 @@ class TestMinikubeRunner(TestCase):
         """
         created_yaml = create_creator_yaml()
         self.assertEqual(created_yaml['spec']['template']['spec']['containers'][0]['env'][1]['value'],
-                         'http://127.0.0.1:8000/players/api/games')
+                         'http://127.0.0.1:8000/players/api/games/')

--- a/players/templates/players/watch.html
+++ b/players/templates/players/watch.html
@@ -17,6 +17,25 @@ var GAME_URL_BASE = "{{ game_url_base }}";
 var GAME_URL_PATH = "{{ game_url_path }}";
 var GAME_URL_PORT = {{ game_url_port }};
 var GAME_SSL_FLAG = "{{ game_ssl_flag }}";
+var GAME_ID = {{ game_id }};
+
+// Sends a AJAX GET request to
+function GetCurrentAvatarID() {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', 'api/games/{{ game_id }}/current_avatar/');
+    xhr.onload = function() {
+        if (xhr.status === 200) {
+            console.log(`I GOT A 200 YEOOO. My game id is: ${GAME_ID} and avatar: ${xhr.responseText}`);
+        }
+        else {
+            alert('Request failed.  Returned status of ' + xhr.status);
+        }
+    };
+
+    xhr.send();
+}
+
+GetCurrentAvatarID();
 
 
 // Send host and port to Unity.

--- a/players/templates/players/watch.html
+++ b/players/templates/players/watch.html
@@ -31,7 +31,7 @@ function GetCurrentAvatarID(gameInstance) {
     xhr.onload = function() {
         if (xhr.status === 200) {
             var CURRENT_AVATAR_ID = JSON.parse(xhr.responseText).current_avatar_id;
-            gameInstance.SendMessage("World Controller", "AvatarID", CURRENT_AVATAR_ID)
+            gameInstance.SendMessage("World Controller", "SetCurrentAvatarID", CURRENT_AVATAR_ID)
         }
         else {
             console.warn('Current avatar ID not resolved! Returned status:' + xhr.status);

--- a/players/templates/players/watch.html
+++ b/players/templates/players/watch.html
@@ -45,12 +45,12 @@ function GetCurrentAvatarID(gameInstance) {
 // Send host and port to Unity.
 function SendAllConnect() {
   console.log(`SendAllConnect function call details: base: ${GAME_URL_BASE} path: ${GAME_URL_PATH} port: ${GAME_URL_PORT} SSL_FLAG: ${GAME_SSL_FLAG}`);
+  GetCurrentAvatarID(gameInstance);
   gameInstance.SendMessage("World Controller", "SetGameURL", GAME_URL_BASE);
   gameInstance.SendMessage("World Controller", "SetGamePort", GAME_URL_PORT);
   gameInstance.SendMessage("World Controller", "SetGamePath", GAME_URL_PATH);
   gameInstance.SendMessage("World Controller", "SetSSL", GAME_SSL_FLAG);
   gameInstance.SendMessage("World Controller", "EstablishConnection");
-  GetCurrentAvatarID(gameInstance);
 }
 
 </script>

--- a/players/templates/players/watch.html
+++ b/players/templates/players/watch.html
@@ -18,24 +18,28 @@ var GAME_URL_PATH = "{{ game_url_path }}";
 var GAME_URL_PORT = {{ game_url_port }};
 var GAME_SSL_FLAG = "{{ game_ssl_flag }}";
 var GAME_ID = {{ game_id }};
+var WEB_HOST_URL = "{{ web_host_base }}";
+
 
 // Sends a AJAX GET request to
-function GetCurrentAvatarID() {
+function GetCurrentAvatarID(gameInstance) {
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', 'api/games/{{ game_id }}/current_avatar/');
+    var protocol = (GAME_SSL_FLAG) ? 'http://' : 'https://';
+    var current_avatar_url = `${protocol}${WEB_HOST_URL}/players/api/games/${GAME_ID}/current_avatar/`;
+
+    xhr.open('GET', current_avatar_url);
     xhr.onload = function() {
         if (xhr.status === 200) {
-            console.log(`I GOT A 200 YEOOO. My game id is: ${GAME_ID} and avatar: ${xhr.responseText}`);
+            var CURRENT_AVATAR_ID = JSON.parse(xhr.responseText).current_avatar_id;
+            gameInstance.SendMessage("World Controller", "AvatarID", CURRENT_AVATAR_ID)
         }
         else {
-            alert('Request failed.  Returned status of ' + xhr.status);
+            console.warn('Current avatar ID not resolved! Returned status:' + xhr.status);
         }
     };
 
     xhr.send();
 }
-
-GetCurrentAvatarID();
 
 
 // Send host and port to Unity.
@@ -46,6 +50,7 @@ function SendAllConnect() {
   gameInstance.SendMessage("World Controller", "SetGamePath", GAME_URL_PATH);
   gameInstance.SendMessage("World Controller", "SetSSL", GAME_SSL_FLAG);
   gameInstance.SendMessage("World Controller", "EstablishConnection");
+  GetCurrentAvatarID(gameInstance);
 }
 
 </script>

--- a/players/tests.py
+++ b/players/tests.py
@@ -282,7 +282,7 @@ class TestViews(TestCase):
         second_user = User.objects.create_user('test2', 'test2@example.com', 'password2')
         second_user.save()
 
-        self.game.can_play = [first_user, second_user]
+        self.game.can_play = [first_user.id, second_user.id]
 
         first_response = first_user.get(reverse('aimmo/current_avatar_in_game', kwargs={'game_id': 1}))
         self.assertEqual(first_response.json()['current_avatar_id'], 1)

--- a/players/tests.py
+++ b/players/tests.py
@@ -1,4 +1,5 @@
 import logging
+import ast
 
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.urlresolvers import reverse
@@ -269,7 +270,6 @@ class TestViews(TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_current_avatar_api_for_unauthorised_games(self):
-        c = Client()
         self.game.public = False
         self.game.can_play = [self.user]
         self.game.save()
@@ -278,17 +278,35 @@ class TestViews(TestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_current_avatar_api_for_two_users(self):
-        first_user = self.login()
+        # Set up the first avatar
+        first_user = self.user
+        models.Avatar(owner=first_user, code=self.CODE, game=self.game).save()
+        client_one = self.login()
+
+        # Set up the second avatar
         second_user = User.objects.create_user('test2', 'test2@example.com', 'password2')
         second_user.save()
+        models.Avatar(owner=second_user, code=self.CODE, game=self.game).save()
+        client_two = Client()
+        client_two.login(username='test2', password='password2')
 
-        self.game.can_play = [first_user.id, second_user.id]
+        self.game.public = True
+        self.game.can_play = [first_user, second_user]
+        self.game.save()
 
-        first_response = first_user.get(reverse('aimmo/current_avatar_in_game', kwargs={'game_id': 1}))
-        self.assertEqual(first_response.json()['current_avatar_id'], 1)
+        first_response = client_one.get(reverse('aimmo/current_avatar_in_game', kwargs={'game_id': 1}))
+        second_response = client_two.get(reverse('aimmo/current_avatar_in_game', kwargs={'game_id': 1}))
 
-        second_response = second_user.get(reverse('aimmo/current_avatar_in_game', kwargs={'game_id': 1}))
-        self.assertEqual(second_response.json()['current_avatar_id'], 2)
+        # Status code starts with 2, success response can be different than 200.
+        self.assertEqual(str(first_response.status_code)[0], 2)
+        self.assertEqual(str(first_response.status_code)[0], 2)
+
+        # JSON is returned as string so needs to be evaluated.
+        first_id = ast.literal_eval(first_response.content)['current_avatar_id']
+        second_id = ast.literal_eval(second_response.content)['current_avatar_id']
+
+        self.assertEqual(first_id, 1)
+        self.assertEqual(second_id, 2)
 
 
 class TestModels(TestCase):

--- a/players/tests.py
+++ b/players/tests.py
@@ -268,6 +268,28 @@ class TestViews(TestCase):
         response = c.get(reverse('aimmo/current_avatar_in_game', kwargs={'game_id': 1}))
         self.assertEqual(response.status_code, 404)
 
+    def test_current_avatar_api_for_unauthorised_games(self):
+        c = Client()
+        self.game.public = False
+        self.game.can_play = [self.user]
+        self.game.save()
+        c = self.login()
+        response = c.get(reverse('aimmo/current_avatar_in_game', kwargs={'game_id': 1}))
+        self.assertEqual(response.status_code, 401)
+
+    def test_current_avatar_api_for_two_users(self):
+        first_user = self.login()
+        second_user = User.objects.create_user('test2', 'test2@example.com', 'password2')
+        second_user.save()
+
+        self.game.can_play = [first_user, second_user]
+
+        first_response = first_user.get(reverse('aimmo/current_avatar_in_game', kwargs={'game_id': 1}))
+        self.assertEqual(first_response.json()['current_avatar_id'], 1)
+
+        second_response = second_user.get(reverse('aimmo/current_avatar_in_game', kwargs={'game_id': 1}))
+        self.assertEqual(second_response.json()['current_avatar_id'], 2)
+
 
 class TestModels(TestCase):
     @classmethod

--- a/players/tests.py
+++ b/players/tests.py
@@ -298,8 +298,8 @@ class TestViews(TestCase):
         second_response = client_two.get(reverse('aimmo/current_avatar_in_game', kwargs={'game_id': 1}))
 
         # Status code starts with 2, success response can be different than 200.
-        self.assertEqual(str(first_response.status_code)[0], 2)
-        self.assertEqual(str(first_response.status_code)[0], 2)
+        self.assertEqual(int(str(first_response.status_code)[0]), 2)
+        self.assertEqual(int(str(first_response.status_code)[0]), 2)
 
         # JSON is returned as string so needs to be evaluated.
         first_id = ast.literal_eval(first_response.content)['current_avatar_id']

--- a/players/tests.py
+++ b/players/tests.py
@@ -263,6 +263,10 @@ class TestViews(TestCase):
         c.post(reverse('aimmo/complete_game', kwargs={'id': 1}), 'static', content_type='application/json')
         self.assertEqual(models.Game.objects.get(id=1).static_data, 'static')
 
+    def test_current_avatar_api_for_non_existant_game(self):
+        c = Client()
+        response = c.get(reverse('aimmo/current_avatar_in_game', kwargs={'game_id': 1}))
+        self.assertEqual(response.status_code, 404)
 
 
 class TestModels(TestCase):

--- a/players/tests.py
+++ b/players/tests.py
@@ -298,8 +298,8 @@ class TestViews(TestCase):
         second_response = client_two.get(reverse('aimmo/current_avatar_in_game', kwargs={'game_id': 1}))
 
         # Status code starts with 2, success response can be different than 200.
-        self.assertEqual(int(str(first_response.status_code)[0]), 2)
-        self.assertEqual(int(str(first_response.status_code)[0]), 2)
+        self.assertEqual(str(first_response.status_code)[0], "2")
+        self.assertEqual(str(first_response.status_code)[0], "2")
 
         # JSON is returned as string so needs to be evaluated.
         first_id = ast.literal_eval(first_response.content)['current_avatar_id']

--- a/players/urls.py
+++ b/players/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     url(r'^api/games/$', views.list_games, name='aimmo/games'),
     url(r'^api/games/(?P<id>[0-9]+)/$', views.get_game, name='aimmo/game_details'),
     url(r'^api/games/(?P<id>[0-9]+)/complete/$', views.mark_game_complete, name='aimmo/complete_game'),
+    url(r'^api/games/(?P<game_id>[0-9]+)/current_avatar/$', views.current_avatar_in_game, name='aimmo/current_avatar_in_game'),
 
     url(r'^jsreverse/$', 'django_js_reverse.views.urls_js', name='aimmo/js_reverse'),  # TODO: Pull request to make django_js_reverse.urls
     url(r'^games/new/$', views.add_game, name='aimmo/new_game'),

--- a/players/views.py
+++ b/players/views.py
@@ -50,7 +50,8 @@ def code(request, id):
     if request.method == 'POST':
         avatar.code = request.POST['code']
         avatar.save()
-        return _post_code_success_response('Your code was saved!<br><br><a href="%s">Watch</a>' % reverse('aimmo/watch', kwargs={'id': game.id}))
+        return _post_code_success_response(
+            'Your code was saved!<br><br><a href="%s">Watch</a>' % reverse('aimmo/watch', kwargs={'id': game.id}))
     else:
         return HttpResponse(avatar.code)
 
@@ -150,7 +151,7 @@ def watch_level(request, num):
 
 
 def _add_and_return_level(num, user):
-    game = Game(generator='Level'+num, name='Level '+num, public=False, main_user=user)
+    game = Game(generator='Level' + num, name='Level ' + num, public=False, main_user=user)
     try:
         game.save()
     except ValidationError as e:
@@ -189,4 +190,4 @@ def current_avatar_in_game(request, game_id):
     except Avatar.DoesNotExist:
         return HttpResponse('Avatar does not exist for this user', status=404)
 
-    return JsonResponse({'current_avatar_id' : avatar.id})
+    return JsonResponse({'current_avatar_id': avatar.id})

--- a/players/views.py
+++ b/players/views.py
@@ -174,3 +174,17 @@ def add_game(request):
     else:
         form = forms.AddGameForm()
     return render(request, 'players/add_game.html', {'form': form})
+
+
+def current_avatar_in_game(request, game_id):
+    game = get_object_or_404(Game, id=game_id)
+
+    if not game.can_user_play(request.user.id):
+        return HttpResponse('User unauthorized to play', status=401)
+
+    try:
+        avatar = game.avatar_set.get(owner=request.user.id)
+    except Avatar.DoesNotExist:
+        return HttpResponse('Avatar does not exist for this user', status=404)
+
+    return JsonResponse({'current_avatar_id' : avatar.id})

--- a/players/views.py
+++ b/players/views.py
@@ -127,6 +127,8 @@ def _render_game(request, game):
     context['game_url_port'] = app_settings.GAME_SERVER_PORT_FUNCTION(game.id)
     context['game_ssl_flag'] = app_settings.GAME_SERVER_SSL_FLAG
     context['game_id'] = game.id
+    context['web_host_base'] = request.get_host()
+
     return render(request, 'players/viewer.html', context)
 
 


### PR DESCRIPTION
This PR will do the following:

- Fixes a URL resolution issue that was missed out on earlier locally. 
- When unity is loaded, we call our newly made function.
- That function will send an AJAX request, also created in the PR, to an API url for that game, and return a JSON.
- We parse the ID from the JSON, send it to the `World Controller`, which is not set up yet - therefore omitted by unity.
- Tests added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/501)
<!-- Reviewable:end -->
