### PR TITLE
Optimise used resources by k8s

### DIFF
--- a/aimmo-game-creator/worker_manager.py
+++ b/aimmo-game-creator/worker_manager.py
@@ -229,11 +229,11 @@ class KubernetesWorkerManager(WorkerManager):
                                     'name': 'aimmo-game',
                                     'resources': {
                                         'limits': {
-                                            'cpu': '1000m',
+                                            'cpu': '300m',
                                             'memory': '128Mi',
                                         },
                                         'requests': {
-                                            'cpu': '100m',
+                                            'cpu': '10m',
                                             'memory': '64Mi',
                                         },
                                     },

--- a/docs/deployment/nginx-setup.md
+++ b/docs/deployment/nginx-setup.md
@@ -11,8 +11,9 @@ For the sake of correct version control, we have saved the yaml files at the tim
 
 To set up from scratch do the following:
 * Install gcloud locally. This is usually done by the following command: `pip install google-cloud`. At the time of writing the version is `0.32.0` and Google Cloud SDK of `189.0.0`.
+* Set the current project for this workspace by typing: `gcloud config set project decent-digit-629`.
 * Authenticate accordingly. You can read up on this [**here**](https://cloud.google.com/appengine/docs/standard/python/oauth/). Usually the following should work: `gcloud auth login`. This will open a web browser and will ask you to authenticate and give permissions to the google account. You should then (or only) run `gcloud auth application-default login` which will create the kubeconfig required for `kubectl` to work. 
-* Get credentials to the appropriate cluster you want to work on by doing the following command: `gcloud container clusters get-credentials [dev/staging/default]`
+* Get credentials to the appropriate cluster you want to work on by doing the following command: `gcloud container clusters get-credentials [dev/staging/default] --zone europe-west1-b`
 * `kubectl apply -f` should now be used on the following files (see path above to find these files):
     * `namespace.yaml`, `default-backend-service.yaml`, `default-backend-deployment.yaml`, `configmap.yaml`, `tcp-services-configmap.yaml`, `udp-services-configmap.yaml`. 
 * Now install no RBAC roles by doing the same on `without-rbac.yaml`.


### PR DESCRIPTION
Part of #570. Might be worth reading.

This PR will decrease a **reserved** quantity of CPU by each `aimmo-game` meaning we can spawn more than our testing has shown (staging proved to be no more than 11-12 games with 1 player each at previous amounts). 

The value `10m` is equivalent to 1% of the CPU power we have on GCE. This is currently 3x nodes of 1vCPU each. Therefore it's 1% of one 1vCPU. 

In simple terms this means that we can probably run around a maximum of 110 games right now.

Another thing this changes is the limit. This means that even with the maximum amount of games requested (allocated) the games can request up to 30% of the vCPU when required. Therefore under massive loads (for the game, not the worker) things can get slow. We first need to assess if they will ever get to that 30%.

Workers remain unchanged as well as the game replication controller.

These values are untested right now because of how we use docker images on dev. It's easier to just push to master, get it deployed on staging and then do stuff with it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/583)
<!-- Reviewable:end -->
