### PR TITLE
Further optimisations of k8s

### DIFF
--- a/aimmo-game/simulation/worker_manager.py
+++ b/aimmo-game/simulation/worker_manager.py
@@ -256,6 +256,10 @@ class KubernetesWorkerManager(WorkerManager):
                                 'cpu': '10m',
                                 'memory': '64Mi',
                             },
+                            'requests': {
+                                'cpu': '7m',
+                                'memory': '32Mi',
+                            },
                         },
                     },
                 ],


### PR DESCRIPTION
This will be an ongoing process because of #586 unfortunately. Until that is solved there will be many PR's coming in.

From the statistics I've seen, these should work fine for now.

Another problem we have is the amount of nodes we run in parallel. They're not very powerful CPU wise, and standalone k8s already takes about half of the mCPU available. We run things like heapster on there. Solution would be to get more powerful individual machines, not scale sideways. Plus loads of other things, but that's for later ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/587)
<!-- Reviewable:end -->
