### PR TITLE
Fix "none" service port in ingress

### DIFF
--- a/aimmo-game-creator/game_manager.py
+++ b/aimmo-game-creator/game_manager.py
@@ -276,7 +276,7 @@ class KubernetesGameManager(GameManager):
         service.create()
 
     def _add_path_to_ingress(self, game_id):
-        backend = kubernetes.client.V1beta1IngressBackend("game-{}".format(game_id, 80))
+        backend = kubernetes.client.V1beta1IngressBackend("game-{}".format(game_id), 80)
         path = kubernetes.client.V1beta1HTTPIngressPath(backend, "/game-{}".format(game_id))
 
         patch = [


### PR DESCRIPTION
After one of the recent PR's we have had an issue where a parameter was left unset leaving an incorrect ingress yaml on our deployment servers. This should solve that.

Tests seem irrelevant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/591)
<!-- Reviewable:end -->
