### PR TITLE
OsError worker_manager bug

### DIFF
--- a/aimmo-game/simulation/worker_managers/__init__.py
+++ b/aimmo-game/simulation/worker_managers/__init__.py
@@ -2,6 +2,6 @@ from kubernetes_worker_manager import KubernetesWorkerManager as _KWorkerManager
 from local_worker_manager import LocalWorkerManager as _LWorkerManager
 
 WORKER_MANAGERS = {
-    'local': _KWorkerManager,
-    'kubernetes': _LWorkerManager,
+    'local': _LWorkerManager,
+    'kubernetes': _KWorkerManager,
 }

--- a/aimmo-game/simulation/worker_managers/local_worker_manager.py
+++ b/aimmo-game/simulation/worker_managers/local_worker_manager.py
@@ -45,7 +45,8 @@ class LocalWorkerManager(WorkerManager):
 
         env['PYTHONPATH'] = data_dir
 
-        process = subprocess.Popen(['python', 'service.py', self.host, str(port), str(data_dir)], cwd=self.worker_directory, env=env)
+        process = subprocess.Popen(['python', 'service.py', self.host, str(port), str(data_dir)],
+                                   cwd=self.worker_directory, env=env)
         atexit.register(process.kill)
         self.workers[player_id] = process
         worker_url = 'http://%s:%d' % (


### PR DESCRIPTION
Small mistake in previous PR where LocalWorkerManager was used in place in K8sWorkerManager and vice-versa.

Fixes #668.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/669)
<!-- Reviewable:end -->
