### PR TITLE
Fixed deprecation warnings for Django 1.10

### DIFF
--- a/aimmo/urls.py
+++ b/aimmo/urls.py
@@ -3,6 +3,7 @@ from django.contrib.auth import views as auth_views
 from django.contrib.auth.decorators import login_required
 from django.views.generic import TemplateView
 from django.views.generic import RedirectView
+from django_js_reverse.views import urls_js
 
 from aimmo import views
 from app_settings import preview_user_required
@@ -25,7 +26,7 @@ urlpatterns = [
     url(r'^api/games/(?P<id>[0-9]+)/complete/$', views.mark_game_complete, name='aimmo/complete_game'),
     url(r'^api/games/(?P<game_id>[0-9]+)/current_avatar/$', views.current_avatar_in_game, name='aimmo/current_avatar_in_game'),
 
-    url(r'^jsreverse/$', 'django_js_reverse.views.urls_js', name='aimmo/js_reverse'),  # TODO: Pull request to make django_js_reverse.urls
+    url(r'^jsreverse/$', urls_js, name='aimmo/js_reverse'),  # TODO: Pull request to make django_js_reverse.urls
     url(r'^games/new/$', views.add_game, name='aimmo/new_game'),
 
     # TODO: this is a quickfix for redirecting for the Unity resources

--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -99,7 +99,7 @@ LOGIN_URL = '/aimmo/accounts/login/'
 
 LOGIN_REDIRECT_URL = '/aimmo/'
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
    'django.contrib.sessions.middleware.SessionMiddleware',
    'django.middleware.locale.LocaleMiddleware',
    'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
RemovedInDjango110Warning: Support for string view arguments to url() is deprecated and will be removed in Django 1.10 (got django_js_reverse.views.urls_js). Pass the callable instead.

(1_10.W001) The MIDDLEWARE_CLASSES setting is deprecated in Django 1.10 and the MIDDLEWARE setting takes precedence. Since you've set MIDDLEWARE, the value of MIDDLEWARE_CLASSES is ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/682)
<!-- Reviewable:end -->
