### PR TITLE
add django.setup() (needed in django 1.10)

### DIFF
--- a/aimmo_runner/runner.py
+++ b/aimmo_runner/runner.py
@@ -42,10 +42,12 @@ def run(use_minikube, server_wait=True, capture_output=False, test_env=False):
         os.environ.setdefault("DJANGO_SETTINGS_MODULE", "example_project.settings")
 
     run_command(['pip', 'install', '-e', ROOT_DIR_LOCATION], capture_output=capture_output)
+
     if not test_env:
         run_command(['python', _MANAGE_PY, 'migrate', '--noinput'], capture_output=capture_output)
         run_command(['python', _MANAGE_PY, 'collectstatic', '--noinput'], capture_output=capture_output)
 
+    django.setup()
     create_superuser_if_missing(username='admin', password='admin')
 
     server_args = []


### PR DESCRIPTION
This is something that was there before when we upgraded from django 1.9 -> 1.10 but must have gotten removed in a revert/rebase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/687)
<!-- Reviewable:end -->
