### PR TITLE
Restrict kubernetes pod kernel capabilities

### DIFF
--- a/aimmo-game-creator/game_manager.py
+++ b/aimmo-game-creator/game_manager.py
@@ -244,6 +244,16 @@ class KubernetesGameManager(GameManager):
                                             "memory": "64Mi",
                                         },
                                     },
+                                    "securityContext": {
+                                        "capabilities": {
+                                            "drop": [
+                                                "all"
+                                            ],
+                                            "add": [
+                                                "NET_BIND_SERVICE"
+                                            ]
+                                        }
+                                    }
                                 },
                             ],
                         },

--- a/aimmo-game-creator/rc-aimmo-game-creator.yaml
+++ b/aimmo-game-creator/rc-aimmo-game-creator.yaml
@@ -33,5 +33,3 @@ spec:
           capabilities:
             drop:
               - all
-            add:
-              - NET_BIND_SERVICE

--- a/aimmo-game-creator/rc-aimmo-game-creator.yaml
+++ b/aimmo-game-creator/rc-aimmo-game-creator.yaml
@@ -29,3 +29,9 @@ spec:
           value: REPLACE_ME
         - name: GAME_MANAGER
           value: kubernetes
+        securityContext:
+          capabilities:
+            drop:
+              - all
+            add:
+              - NET_BIND_SERVICE

--- a/aimmo-game/simulation/worker_managers/kubernetes_worker_manager.py
+++ b/aimmo-game/simulation/worker_managers/kubernetes_worker_manager.py
@@ -58,6 +58,16 @@ class KubernetesWorkerManager(WorkerManager):
                                     'memory': '32Mi',
                                 },
                             },
+                            'securityContext': {
+                                'capabilities': {
+                                    'drop': [
+                                        'all'
+                                    ],
+                                    'add': [
+                                        'NET_BIND_SERVICE'
+                                    ]
+                                }
+                            }
                         },
                     ],
                 },


### PR DESCRIPTION
Please read #689 before reviewing!

This PR will increase our pod security from kubesec rating 7 to 8. The next step would be to completely remove root access, but that was quite difficult to figure out as we don't assign and uID or gIDs right now.

A simple scan of existing game pods for example:

```
(aimmo-UXHtE3Rq) bash-3.2$ kubectl -n default plugin scan pod/game-1-zzn2n
scanning pod game-1-zzn2n
pod/game-1-zzn2n kubesec.io score 8
```

The advisory is now gone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/690)
<!-- Reviewable:end -->
