### PR TITLE
Added requests to requirements.txt

### DIFF
--- a/aimmo-game-worker/requirements.txt
+++ b/aimmo-game-worker/requirements.txt
@@ -1,1 +1,2 @@
 flask
+requests

--- a/aimmo-game-worker/requirements.txt
+++ b/aimmo-game-worker/requirements.txt
@@ -1,2 +1,3 @@
 flask
 requests
+six

--- a/aimmo-game-worker/setup.py
+++ b/aimmo-game-worker/setup.py
@@ -9,6 +9,7 @@ setup(
     install_requires=[
         'flask',
         'requests',
+        'six'
     ],
     tests_require=[
         'httmock',


### PR DESCRIPTION
When `pykube` was removed from `requirements.txt` this resulted in an `ImportError` for the `requests` module. This is because `requests` was a dependency in our project (and in `pykube`), but not listed in `requirements.txt`. We should consider using `pipenv` in our containers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/717)
<!-- Reviewable:end -->
