### PR TITLE
upgrade k8s requirements

### DIFF
--- a/aimmo-game-creator/requirements.txt
+++ b/aimmo-game-creator/requirements.txt
@@ -1,2 +1,2 @@
 eventlet
-kubernetes == 5.0.0
+kubernetes == 6.0.0


### PR DESCRIPTION
According to the k8s python-client changelog (https://github.com/kubernetes-client/python/blob/master/CHANGELOG.md), `delete_namespaced_service` takes a body parameter in version 6.0. This fixes https://github.com/ocadotechnology/aimmo/issues/718. Has been tested on dev.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/719)
<!-- Reviewable:end -->
