### PR TITLE
Only re-render `IDEEditor` component if props change

### DIFF
--- a/game_frontend/src/components/IDEEditor/index.js
+++ b/game_frontend/src/components/IDEEditor/index.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 import AceEditor from 'react-ace'
 import 'brace/theme/idle_fingers'
 import 'brace/mode/python'
@@ -13,12 +13,7 @@ export const IDEEditorLayout = styled.div`
   background-color: #2F4F4F;
   grid-area: ide-editor;
 `
-export class IDEEditor extends Component {
-  shouldComponentUpdate(nextProps) {
-    const differentCode = this.props.code !== nextProps.code
-    return differentCode
-  }
-
+export class IDEEditor extends PureComponent {
   render() {
     return (
       <IDEEditorLayout>

--- a/game_frontend/src/components/IDEEditor/index.js
+++ b/game_frontend/src/components/IDEEditor/index.js
@@ -14,7 +14,12 @@ export const IDEEditorLayout = styled.div`
   grid-area: ide-editor;
 `
 export class IDEEditor extends Component {
-  render () {
+  shouldComponentUpdate(nextProps) {
+    const differentCode = this.props.code !== nextProps.code
+    return differentCode
+  }
+
+  render() {
     return (
       <IDEEditorLayout>
         <AceEditor


### PR DESCRIPTION
Now that IDE is an container, a change in `state.consoleLog.logs` was causing a re-render in `IDEEditor`.

To stop this I have made IDEEditor a PureComponent to reflect that it only derives itself from props

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/723)
<!-- Reviewable:end -->
