### PR TITLE
Don't send empty logs

### DIFF
--- a/aimmo-game/service.py
+++ b/aimmo-game/service.py
@@ -72,9 +72,12 @@ def remove_session_id_from_mappings(sid,
 
 
 def send_logs(session_id_to_avatar_id, logs_provider):
+    def should_send_logs(logs):
+        return logs is not None and logs != ''
+
     for sid, avatar_id in session_id_to_avatar_id.iteritems():
         avatar_logs = logs_provider.get_user_logs(avatar_id)
-        if avatar_logs is not None and avatar_logs != '':
+        if should_send_logs(avatar_logs):
             socketio_server.emit(
                 'log',
                 avatar_logs,

--- a/aimmo-game/service.py
+++ b/aimmo-game/service.py
@@ -74,11 +74,12 @@ def remove_session_id_from_mappings(sid,
 def send_logs(session_id_to_avatar_id, logs_provider):
     for sid, avatar_id in session_id_to_avatar_id.iteritems():
         avatar_logs = logs_provider.get_user_logs(avatar_id)
-        socketio_server.emit(
-            'log',
-            avatar_logs,
-            room=sid,
-        )
+        if avatar_logs is not None and avatar_logs != '':
+            socketio_server.emit(
+                'log',
+                avatar_logs,
+                room=sid,
+            )
 
 
 def send_game_state(session_id_to_avatar_id):
@@ -95,7 +96,6 @@ def send_updates(session_id_to_avatar_id=_default_session_id_to_avatar_id_mappin
                       logs_provider=_default_logs_provider):
     send_game_state(session_id_to_avatar_id)
     send_logs(session_id_to_avatar_id, logs_provider)
-
 
 
 def get_game_state(state_provider=_default_state_provider):

--- a/aimmo-game/tests/test_socketio.py
+++ b/aimmo-game/tests/test_socketio.py
@@ -62,14 +62,38 @@ class TestSocketio(TestCase):
     def test_send_updates_for_one_user(self, mocked_socketio,
                                        mocked_game_state):
         self.mocked_mappings[self.sid] = 1
+        self.mocked_logs_provider.set_user_logs(self.mocked_mappings[self.sid], 'Logs one')
 
         service.send_updates(session_id_to_avatar_id=self.mocked_mappings,
                              logs_provider=self.mocked_logs_provider)
 
         game_state_call = mock.call('game-state', {'foo': 'bar'}, room=self.sid)
-        log_call = mock.call('log', None, room=self.sid)
+        log_call = mock.call('log', 'Logs one', room=self.sid)
 
         mocked_socketio.emit.assert_has_calls([game_state_call, log_call], any_order=True)
+
+    @mock.patch('service.get_game_state', return_value={'foo': 'bar'})
+    @mock.patch('service.socketio_server')
+    def test_no_logs_not_emitted(self, mocked_socketio,
+                                 mocked_game_state):
+        """ If there are no logs for an avatar, no logs should be emitted. """
+        self.mocked_mappings[self.sid] = 1
+        service.send_updates(session_id_to_avatar_id=self.mocked_mappings,
+                             logs_provider=self.mocked_logs_provider)
+
+        mocked_socketio.emit.assert_called_once_with('game-state', {'foo': 'bar'}, room=self.sid)
+
+    @mock.patch('service.get_game_state', return_value={'foo': 'bar'})
+    @mock.patch('service.socketio_server')
+    def test_empty_logs_not_emitted(self, mocked_socketio,
+                                 mocked_game_state):
+        """ If the logs are an empty sting, no logs should be emitted. """
+        self.mocked_mappings[self.sid] = 1
+        self.mocked_logs_provider.set_user_logs(self.mocked_mappings[self.sid], '')
+        service.send_updates(session_id_to_avatar_id=self.mocked_mappings,
+                             logs_provider=self.mocked_logs_provider)
+
+        mocked_socketio.emit.assert_called_once_with('game-state', {'foo': 'bar'}, room=self.sid)
 
     @mock.patch('service.get_game_state', return_value={'foo': 'bar'})
     @mock.patch('service.socketio_server')
@@ -77,6 +101,9 @@ class TestSocketio(TestCase):
                                              mocked_game_state):
         self.mocked_mappings[self.sid] = 1
         self.mocked_mappings['differentsid'] = 2
+
+        self.mocked_logs_provider.set_user_logs(self.mocked_mappings[self.sid], 'Logs one')
+        self.mocked_logs_provider.set_user_logs(self.mocked_mappings['differentsid'], 'Logs two')
 
         service.send_updates(session_id_to_avatar_id=self.mocked_mappings,
                              logs_provider=self.mocked_logs_provider)
@@ -90,11 +117,11 @@ class TestSocketio(TestCase):
                                              room='differentsid')
 
         user_one_log_call = mock.call('log',
-                                      None,
+                                      'Logs one',
                                       room=self.sid)
 
         user_two_log_call = mock.call('log',
-                                      None,
+                                      'Logs two',
                                       room='differentsid')
 
         mocked_socketio.emit.assert_has_calls([user_one_game_state_call,

--- a/aimmo-game/tests/test_socketio.py
+++ b/aimmo-game/tests/test_socketio.py
@@ -22,8 +22,7 @@ class TestSocketio(TestCase):
 
     @mock.patch('service.get_game_state', return_value={'foo': 'bar'})
     @mock.patch('service.socketio_server')
-    def test_socketio_emit_called(self, mocked_socketio,
-                                  mocked_game_state):
+    def test_socketio_emit_called(self, mocked_socketio, mocked_game_state):
         service.world_update_on_connect(self.sid, self.environ,
                                         session_id_to_avatar_id=self.mocked_mappings)
 
@@ -31,8 +30,7 @@ class TestSocketio(TestCase):
 
     @mock.patch('service.get_game_state', return_value={'foo': 'bar'})
     @mock.patch('service.socketio_server')
-    def test_matched_session_id_to_avatar_id_mapping(self, mocked_socketio,
-                                                     mocked_game_state):
+    def test_matched_session_id_to_avatar_id_mapping(self, mocked_socketio, mocked_game_state):
         self.assertEqual(len(self.mocked_mappings), 0)
 
         service.world_update_on_connect(self.sid, self.environ,
@@ -44,8 +42,7 @@ class TestSocketio(TestCase):
 
     @mock.patch('service.get_game_state', return_value={'foo': 'bar'})
     @mock.patch('service.socketio_server')
-    def test_no_match_session_id_to_avatar_id_mapping(self, mocked_socketio,
-                                                      mocked_game_state):
+    def test_no_match_session_id_to_avatar_id_mapping(self, mocked_socketio, mocked_game_state):
         self.environ['QUERY_STRING'] = 'corrupted!@$%string123'
 
         self.assertEqual(len(self.mocked_mappings), 0)
@@ -59,8 +56,7 @@ class TestSocketio(TestCase):
 
     @mock.patch('service.get_game_state', return_value={'foo': 'bar'})
     @mock.patch('service.socketio_server')
-    def test_send_updates_for_one_user(self, mocked_socketio,
-                                       mocked_game_state):
+    def test_send_updates_for_one_user(self, mocked_socketio, mocked_game_state):
         self.mocked_mappings[self.sid] = 1
         self.mocked_logs_provider.set_user_logs(self.mocked_mappings[self.sid], 'Logs one')
 
@@ -74,8 +70,7 @@ class TestSocketio(TestCase):
 
     @mock.patch('service.get_game_state', return_value={'foo': 'bar'})
     @mock.patch('service.socketio_server')
-    def test_no_logs_not_emitted(self, mocked_socketio,
-                                 mocked_game_state):
+    def test_no_logs_not_emitted(self, mocked_socketio, mocked_game_state):
         """ If there are no logs for an avatar, no logs should be emitted. """
         self.mocked_mappings[self.sid] = 1
         service.send_updates(session_id_to_avatar_id=self.mocked_mappings,
@@ -85,8 +80,7 @@ class TestSocketio(TestCase):
 
     @mock.patch('service.get_game_state', return_value={'foo': 'bar'})
     @mock.patch('service.socketio_server')
-    def test_empty_logs_not_emitted(self, mocked_socketio,
-                                 mocked_game_state):
+    def test_empty_logs_not_emitted(self, mocked_socketio, mocked_game_state):
         """ If the logs are an empty sting, no logs should be emitted. """
         self.mocked_mappings[self.sid] = 1
         self.mocked_logs_provider.set_user_logs(self.mocked_mappings[self.sid], '')
@@ -97,8 +91,7 @@ class TestSocketio(TestCase):
 
     @mock.patch('service.get_game_state', return_value={'foo': 'bar'})
     @mock.patch('service.socketio_server')
-    def test_send_updates_for_multiple_users(self, mocked_socketio,
-                                             mocked_game_state):
+    def test_send_updates_for_multiple_users(self, mocked_socketio, mocked_game_state):
         self.mocked_mappings[self.sid] = 1
         self.mocked_mappings['differentsid'] = 2
 


### PR DESCRIPTION
This PR means that if the logs are the empty string or `None`, we no longer emit them on the socket. This stops extra empty lines being printed on the front end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/732)
<!-- Reviewable:end -->
