### PR TITLE
Write setup script mac

### DIFF
--- a/aimmo-setup.py
+++ b/aimmo-setup.py
@@ -8,9 +8,10 @@ from subprocess import PIPE, CalledProcessError
 class Result:
     '''
     Blank object used to store the result of a command run by Popen, do not use this
-    outside of the setup script. 
+    outside of the setup script.
     '''
     pass
+
 
 def _cmd(command):
     '''
@@ -31,12 +32,13 @@ def _cmd(command):
     result.command = command
 
     if p.returncode != 0:
-        print 'Error executing command [%s]' % command
-        print 'stderr: [%s]' % stderr
-        print 'stdout: [%s]' % stdout
+        print('Error executing command [%s]' % command)
+        print('stderr: [%s]' % stderr)
+        print('stdout: [%s]' % stdout)
         raise CalledProcessError
 
-    return result 
+    return result
+
 
 # First we find and store the OS we are currently on, 0 if we didn't figure it out
 # Although if you're not using one the options above for development what are you doing with your life.
@@ -49,16 +51,16 @@ OStypes = {
 
 if platform.system() == 'Darwin':
     hostOS = OStypes["mac"]
-    print 'MAC found!'
+    print('MAC found!')
 elif platform.system() == 'Windows':
     hostOS = OStypes["windows"]
-    print 'WINDOWS found!'
+    print('WINDOWS found!')
 elif platform.system() == 'Linux':
     hostOS = OStypes["linux"]
-    print 'LINUX found!'
+    print('LINUX found!')
 
 print '---------------------------------------------------------------------------------------------------'
-print '| Welcome to aimmo! This script should make your life alil easier, just be kind if it doesnt work |'        
+print '| Welcome to aimmo! This script should make your life alil easier, just be kind if it doesnt work |'  
 print '---------------------------------------------------------------------------------------------------'
 print '| You may be asked to enter your password during this setup                                       |'
 print '---------------------------------------------------------------------------------------------------'
@@ -76,68 +78,68 @@ if hostOS == OStypes["mac"]:
     """
     try:
         result = _cmd('brew -v')
-        print 'Homebrew Found...'
-        print result.stdout
+        print('Homebrew Found...')
+        print(result.stdout)
 
         try:
-            print 'Installing Yarn...'
+            print('Installing Yarn...')
             result = _cmd('brew install yarn')
 
-            print 'Installing pipenv...'
+            print('Installing pipenv...')
             result = _cmd('brew install pipenv')
 
-            print 'Running "pipenv install"...'
+            print('Running "pipenv install"...')
             result = _cmd('pipenv install')
-            
-            print 'Installing Docker...'
+
+            print('Installing Docker...')
             result = _cmd('brew cask install docker')
 
-            print 'Installing Virtualbox...'
+            print('Installing Virtualbox...')
             result = _cmd('brew cask install virtualbox')
-        
-            print 'Setting up frontend dependencies...'
+
+            print('Setting up frontend dependencies...')
             result = _cmd('cd ./game_frontend')
             result = _cmd('yarn')
             result = _cmd('cd ..')
-            
-            print 'Installing minikube...'
+
+            print('Installing minikube...')
             result = _cmd('curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-darwin-amd64')
             result = _cmd('chmod +x minikube')
             result = _cmd('sudo mv minikube /usr/local/bin/')
 
-            print 'Installing Kubernetes...'
+            print('Installing Kubernetes...')
             result = _cmd('curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/darwin/amd64/kubectl')
             result = _cmd('chmod +x kubectl')
             result = _cmd('sudo mv kubectl /usr/local/bin/')
 
-            print 'adding aimmo to /etc/hosts...'
+            print('adding aimmo to /etc/hosts...')
             result = _cmd("sudo sh -c 'echo 192.168.99.100 local.aimmo.codeforlife.education >> /etc/hosts'")
 
-            print '---------------------------------------------------------------------------------------------------'
-            print '| You now need to get the unity package from the aimmo-unity repo, place it in aimmo/static/unity |' 
-            print '| Also, just open up docker to finalize the install for it, then you can run aimmo.               |'        
-            print '---------------------------------------------------------------------------------------------------'
-            
+            print('---------------------------------------------------------------------------------------------------')
+            print('| You now need to get the unity package from the aimmo-unity repo, place it in aimmo/static/unity |')
+            print('| Also, just open up docker to finalize the install for it, then you can run aimmo.               |')
+            print('---------------------------------------------------------------------------------------------------')
+
         except CalledProcessError as e:
-            print 'A command has return an exit code != 0, so something has gone wrong.'
+            print('A command has return an exit code != 0, so something has gone wrong.')
         except OSError as e:
-            print "Tried to execute a command that didn't exist."
+            print("Tried to execute a command that didn't exist.")
             print result.stderr
         except ValueError as e:
-            print 'Tried to execute a command with invalid arguments'
+            print('Tried to execute a command with invalid arguments')
             print result.stderr
 
     except Exception as e:
-        print 'Something went wrong :s, check if Homebrew is installed correctly.'
-        print "If it's not that, then something went wrong during the script unexpectedly,"
-        print "don't be alarmed, you may have to just try the manual setup. Sorry :("
-        print result.stderr
+        print('Something went wrong :s, check if Homebrew is installed correctly.')
+        print("If it's not that, then something went wrong during the script unexpectedly,")
+        print("don't be alarmed, you may have to just try the manual setup. Sorry :(")
+        print(result.stderr)
 
-    
+
 elif hostOS == OStypes["windows"]:
     pass
 elif hostOS == OStypes["linux"]:
     pass
 else:
-    print "Could not detect operating system/ it looks like you're using"
-    print 'something other then windows, mac, or linux. Y u do dis?'
+    print("Could not detect operating system/ it looks like you're using")
+    print('something other then windows, mac, or linux. Y u do dis?')

--- a/aimmo-setup.py
+++ b/aimmo-setup.py
@@ -59,11 +59,10 @@ elif platform.system() == 'Linux':
     hostOS = OStypes["linux"]
     print('LINUX found!')
 
-print '---------------------------------------------------------------------------------------------------'
-print '| Welcome to aimmo! This script should make your life alil easier, just be kind if it doesnt work |'  
-print '---------------------------------------------------------------------------------------------------'
-print '| You may be asked to enter your password during this setup                                       |'
-print '---------------------------------------------------------------------------------------------------'
+print('---------------------------------------------------------------------------------------------------')
+print('| Welcome to aimmo! This script should make your life alil easier, just be kind if it doesnt work |') 
+print('| You may be asked to enter your password during this setup                                       |')
+print('---------------------------------------------------------------------------------------------------')
 
 if hostOS == OStypes["mac"]:
     """

--- a/aimmo-setup.py
+++ b/aimmo-setup.py
@@ -98,9 +98,7 @@ if hostOS == OStypes["mac"]:
             result = _cmd('brew cask install virtualbox')
 
             print('Setting up frontend dependencies...')
-            result = _cmd('cd ./game_frontend')
-            result = _cmd('yarn')
-            result = _cmd('cd ..')
+            result = _cmd('cd ./game_frontend | yarn')
 
             print('Installing minikube...')
             result = _cmd('curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-darwin-amd64')

--- a/aimmo-setup.py
+++ b/aimmo-setup.py
@@ -6,12 +6,19 @@ import shlex
 from subprocess import PIPE, CalledProcessError
 
 class Result:
+    '''
+    Blank object used to store the result of a command run by Popen, do not use this
+    outside of the setup script. 
+    '''
     pass
 
-def cmd(command):
+def _cmd(command):
     '''
-    This takes in a command you wish to run, as a string, and excecutes it for you. This will work for commands run
-    on Linux, Mac, and Windows. 
+    :param command: command/subprocess to be run, as a string
+    Takes in a command/subprocess, runs it, then returns an object containing all
+    output from the process. DO NOT USE outside of the aimmo-setup script, and DO NOT INCLUDE
+    in any release build, as this function is able to run bash scripts, will sudo access if
+    specified. 
     '''
     result = Result()
 
@@ -68,43 +75,43 @@ if hostOS == OStypes["mac"]:
     Note needs homebrew pre-installed in order to run, will let the user know if they don't have it.
     """
     try:
-        result = cmd('brew -v')
+        result = _cmd('brew -v')
         print 'Homebrew Found...'
         print result.stdout
 
         try:
             print 'Installing Yarn...'
-            result = cmd('brew install yarn')
+            result = _cmd('brew install yarn')
 
             print 'Installing pipenv...'
-            result = cmd('brew install pipenv')
+            result = _cmd('brew install pipenv')
 
             print 'Running "pipenv install"...'
-            result = cmd('pipenv install')
+            result = _cmd('pipenv install')
             
             print 'Installing Docker...'
-            result = cmd('brew cask install docker')
+            result = _cmd('brew cask install docker')
 
             print 'Installing Virtualbox...'
-            result = cmd('brew cask install virtualbox')
+            result = _cmd('brew cask install virtualbox')
         
             print 'Setting up frontend dependencies...'
-            result = cmd('cd ./game_frontend')
-            result = cmd('yarn')
-            result = cmd('cd ..')
+            result = _cmd('cd ./game_frontend')
+            result = _cmd('yarn')
+            result = _cmd('cd ..')
             
             print 'Installing minikube...'
-            result = cmd('curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-darwin-amd64')
-            result = cmd('chmod +x minikube')
-            result = cmd('sudo mv minikube /usr/local/bin/')
+            result = _cmd('curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-darwin-amd64')
+            result = _cmd('chmod +x minikube')
+            result = _cmd('sudo mv minikube /usr/local/bin/')
 
             print 'Installing Kubernetes...'
-            result = cmd('curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/darwin/amd64/kubectl')
-            result = cmd('chmod +x kubectl')
-            result = cmd('sudo mv kubectl /usr/local/bin/')
+            result = _cmd('curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/darwin/amd64/kubectl')
+            result = _cmd('chmod +x kubectl')
+            result = _cmd('sudo mv kubectl /usr/local/bin/')
 
             print 'adding aimmo to /etc/hosts...'
-            result = cmd("sudo sh -c 'echo 192.168.99.100 local.aimmo.codeforlife.education >> /etc/hosts'")
+            result = _cmd("sudo sh -c 'echo 192.168.99.100 local.aimmo.codeforlife.education >> /etc/hosts'")
 
             print '---------------------------------------------------------------------------------------------------'
             print '| You now need to get the unity package from the aimmo-unity repo, place it in aimmo/static/unity |' 
@@ -122,7 +129,7 @@ if hostOS == OStypes["mac"]:
 
     except Exception as e:
         print 'Something went wrong :s, check if Homebrew is installed correctly.'
-        print "If it's not that then something went wrong during the script unexpectedly,"
+        print "If it's not that, then something went wrong during the script unexpectedly,"
         print "don't be alarmed, you may have to just try the manual setup. Sorry :("
         print result.stderr
 

--- a/aimmo-setup.py
+++ b/aimmo-setup.py
@@ -6,6 +6,16 @@ import shlex
 from subprocess import PIPE, CalledProcessError
 
 
+# First we find and store the OS we are currently on, 0 if we didn't figure out which one
+hostOS = 0
+OStypes = {
+    "mac": 1,
+    "windows": 2,
+    "linux": 3
+}
+valid = {"yes": True, "y": True, "ye": True, "no": False, "n": False}
+
+
 class Result:
     '''
     Blank object used to store the result of a command run by Popen, do not use this
@@ -16,11 +26,12 @@ class Result:
 
 def _cmd(command):
     '''
-    :param command: command/subprocess to be run, as a string
+    :param command: command/subprocess to be run, as a string.
+
     Takes in a command/subprocess, runs it, then returns an object containing all
-    output from the process. DO NOT USE outside of the aimmo-setup script, and DO NOT INCLUDE
-    in any release build, as this function is able to run bash scripts, will sudo access if
-    specified.
+    output from the process. DO NOT USE outside of the AI:MMO-setup script, and DO NOT INCLUDE
+    in any release build, as this function is able to run bash scripts, and can run commands
+    with sudo if specified.
     '''
     result = Result()
 
@@ -33,111 +44,323 @@ def _cmd(command):
     result.command = command
 
     if p.returncode != 0:
-        print('Error executing command [%s]' % command)
-        print('stderr: [%s]' % stderr)
-        print('stdout: [%s]' % stdout)
         raise CalledProcessError
 
     return result
 
 
-# First we find and store the OS we are currently on, 0 if we didn't figure it out
-# Although if you're not using one the options above for development what are you doing with your life.
-hostOS = 0
-OStypes = {
-    "mac": 1,
-    "windows": 2,
-    "linux": 3
-}
+def install_yarn(operatingSystem):
+    '''
+    :param operatingSystem: values from the OStypes dict. (Should be updated to enum once python 3 is availible)
 
-if platform.system() == 'Darwin':
-    hostOS = OStypes["mac"]
-    print('MAC found!')
-elif platform.system() == 'Windows':
-    hostOS = OStypes["windows"]
-    print('WINDOWS found!')
-elif platform.system() == 'Linux':
-    hostOS = OStypes["linux"]
-    print('LINUX found!')
+    OS dependant, so it must be passed to this function in order to run correctly.
+    '''
+    print('Installing Yarn...')
+    if operatingSystem == OStypes['mac']:
+        result = _cmd('brew install yarn')
+    elif operatingSystem == OStypes['linux']:
+        result = _cmd('sudo apt-get install yarn')
+    elif operatingSystem == OStypes['windows']:
+        pass
+    else:
+        raise Exception
+
+
+def install_pipenv(operatingSystem):
+    '''
+    :param operatingSystem: values from the OStypes dict. (Should be updated to enum once python 3 is availible)
+
+    OS dependant, so it must be passed to this function in order to run correctly.
+    '''
+    print('Installing pipenv...')
+    if operatingSystem == OStypes['mac']:
+        result = _cmd('brew install pipenv')
+    elif operatingSystem == OStypes['linux']:
+        result = _cmd('pip install pipenv')
+    elif operatingSystem == OStypes['windows']:
+        pass
+    else:
+        raise Exception
+
+
+def install_docker(operatingSystem):
+    '''
+    :param operatingSystem: values from the OStypes dict. (Should be updated to enum once python 3 is availible)
+
+    OS dependant, so it must be passed to this function in order to run correctly.
+    '''
+    print('Installing Docker...')
+    if operatingSystem == OStypes['mac']:
+        result = _cmd('brew cask install docker')
+    elif operatingSystem == OStypes['linux']:
+        result = _cmd('sudo apt-get install docker-ce')
+    elif operatingSystem == OStypes['windows']:
+        pass
+    else:
+        raise Exception
+
+
+def install_virtualbox(operatingSystem):
+    '''
+    :param operatingSystem: values from the OStypes dict. (Should be updated to enum once python 3 is availible)
+
+    OS dependant, so it must be passed to this function in order to run correctly.
+    '''
+    print('Installing Virtualbox...')
+    if operatingSystem == OStypes['mac']:
+        result = _cmd('brew cask install virtualbox')
+    elif operatingSystem == OStypes['linux']:
+        result = _cmd('sudo apt-get install docker-ce')
+    elif operatingSystem == OStypes['windows']:
+        pass
+    else:
+        raise Exception
+
+
+def install_minikube(operatingSystem):
+    '''
+    :param operatingSystem: values from the OStypes dict. (Should be updated to enum once python 3 is availible)
+
+    OS dependant, so it must be passed to this function in order to run correctly.
+    '''
+    print('Installing minikube...')  # If minikube version changes this will need updating
+    if operatingSystem == OStypes['mac']:
+        result = _cmd('curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-darwin-amd64')
+        result = _cmd('chmod +x minikube')
+        result = _cmd('sudo mv minikube /usr/local/bin/')
+    elif operatingSystem == OStypes['linux']:
+        result = _cmd('curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-linux-amd64')
+        result = _cmd('chmod +x minikube')
+        result = _cmd('sudo mv minikube /usr/local/bin/')
+    elif operatingSystem == OStypes['windows']:
+        pass
+    else:
+        raise Exception
+
+
+def install_kurbernetes(operatingSystem):
+    '''
+    :param operatingSystem: values from the OStypes dict. (Should be updated to enum once python 3 is availible)
+
+    OS dependant, so it must be passed to this function in order to run correctly.
+    '''
+    print('Installing Kubernetes...')  # If kubernetes version changes this will need updating
+    if operatingSystem == OStypes['mac']:
+        result = _cmd('curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/darwin/amd64/kubectl')
+        result = _cmd('chmod +x kubectl')
+        result = _cmd('sudo mv kubectl /usr/local/bin/')
+    elif operatingSystem == OStypes['linux']:
+        result = _cmd('sudo snap install kubectl --classic')
+    elif operatingSystem == OStypes['windows']:
+        pass
+    else:
+        raise Exception
+
+
+def install_pip():  # Linux only
+    print('Installing pip...')
+    result = _cmd('sudo apt-get install python-pip')
+
+
+def install_snap():  # Linux only
+    print('Installing snap...')
+    result = _cmd('sudo apt install snapd')
+
+
+def install_nodejs():  # Linux only
+    print('Installing Nodejs...')
+    result = _cmd('sudo apt-get install -y nodejs')
+
+
+def run_pipenv_install():  # OS inderpendant
+    print('Running "pipenv install"...')
+    result = _cmd('pipenv install')
+
+
+def set_up_frontend_dependencies():  # Mac & Linux only
+    print('Setting up frontend dependencies...')
+    result = _cmd('cd ./game_frontend | yarn')
+
+
+def check_homebrew():  # Mac only
+    result = _cmd('brew -v')
+    print('Homebrew Found...')
+
+
+def check_for_cmdtest():  # Linux/Ubuntu only
+    '''
+    This function is for use within the linux setup section of the script. It checks if
+    the cmdtest package is installed, if it is we ask the user if we can remove it, if yes
+    we remove the package, if not the process continues without removing it.
+    '''
+    p = subprocess.Popen("dpkg-query -W -f='${status}' cmdtest")
+    (stdout, _) = p.communicate()
+    if 'unknown' not in stdout:
+        print('Looks like cmdtest is installed on your machine, this can cause issues when installing Yarn.')
+
+        answer = False
+        answered = False
+        while not answered:
+            choice = raw_input('Is it okay if I remove cmdtest? [y/n]').lower()
+            if choice in valid:
+                answer = valid[choice]
+                answered = True
+            else:
+                print("Please answer 'yes' or 'no' ('y' or 'n').")
+        if answer:
+            print('Removing cmdtest...')
+            result = _cmd('apt-get remove cmdtest')
+        else:
+            print('Continuing without removing cmdtest...')
+
+
+def update_apt_get():  # Linux only
+    print('Updating apt-get...')
+    result = _cmd('sudo apt-get update')
+
+
+def get_nodejs():  # Linux only
+    print('Getting Nodejs...')
+    result = _cmd('curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -')
+
+
+def add_aimmo_to_hosts_file():  # Mac & Linux only
+    with open("/etc/hosts", "r") as hostfile:
+        data = hostfile.read().replace('\n', '')
+    if "192.168.99.100 local.AI:MMO.codeforlife.education" not in data:
+        print('Adding AI:MMO to /etc/hosts...')
+        result = _cmd("sudo sh -c 'echo 192.168.99.100 local.aimmo.codeforlife.education >> /etc/hosts'")
+    else:
+        print('AI:MMO already present in /etc/hosts...')
+
+
+def add_parcel_bundler():  # Mac & Linux only
+    print('Adding parcel-bundler globally...')
+    result = _cmd('yarn global add parcel-bundler')
+
+
+def configure_yarn_repo():  # Linux only
+    print('Configuring Yarn repository...')
+    result = _cmd('curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -')
+    result = _cmd('echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list')
+
+
+def mac_setup(hostOS):
+    '''
+    Runs the list of commands, sequencially, needed in order to set up AI:MMO for a mac.
+    After this has been run the user needs to open docker to finalize it's install,
+    and get the unity package for AI:MMO from AI:MMO-unity.
+    '''
+    try:
+        check_homebrew()
+        install_yarn(hostOS)
+        add_parcel_bundler()
+        set_up_frontend_dependencies()
+        install_pipenv(hostOS)
+        run_pipenv_install()
+        install_docker(hostOS)
+        install_virtualbox(hostOS)
+        install_minikube(hostOS)
+        install_kurbernetes(hostOS)
+
+        print('---------------------------------------------------------------------------------------------------')
+        print("| You now need to get the unity package from the AI:MMO-unity repo, place it's contents           |")
+        print('| in aimmo/aimmo/static/unity.  (folder may not exist yet)                                        |')
+        print('| You may also need to open docker, just to finalize the install                                  |')
+        print('---------------------------------------------------------------------------------------------------')
+        print('| Everything should now be ready for you to use aimmo! :D                                         |')
+        print('---------------------------------------------------------------------------------------------------')
+
+    except CalledProcessError as e:
+        print('A command has return an exit code != 0, so something has gone wrong.')
+        print(e)
+    except OSError as e:
+        print("Tried to execute a command that didn't exist.")
+        print(e)
+    except ValueError as e:
+        print('Tried to execute a command with invalid arguments')
+        print(e)
+    except Exception as e:
+        print("Something went very wrong, maybe i couldn't read hosts? otherwise I have no idea what it was D:")
+        print(e)
+
+
+def windows_setup(hostOS):
+    pass
+
+
+def linux_setup(hostOS):
+    try:
+        update_apt_get()
+        get_nodejs()
+        install_nodejs()
+        check_for_cmdtest()
+        configure_yarn_repo()
+        install_yarn()
+        add_parcel_bundler()
+        install_pip()
+        install_pipenv(hostOS)
+        set_up_frontend_dependencies()
+        install_kurbernetes(hostOS)
+        install_docker(hostOS)
+        add_aimmo_to_hosts_file()
+
+        print('---------------------------------------------------------------------------------------------------')
+        print("| You now need to get the unity package from the AI:MMO-unity repo, place it's contents           |")
+        print('| in aimmo/aimmo/static/unity  (folder may not exist yet)                                         |')
+        print('---------------------------------------------------------------------------------------------------')
+        print('| Everything should now be ready for you to use aimmo! :D                                         |')
+        print('---------------------------------------------------------------------------------------------------')
+
+    except CalledProcessError as e:
+        print('Command returned an exit code != 0, so something has gone wrong.')
+        print(e)
+    except OSError as e:
+        print("Tried to execute a command that didn't exist.")
+        print(e)
+    except ValueError as e:
+        print('Tried to execute a command with invalid arguments')
+        print(e)
+    except Exception as e:
+        print("Something went very wrong, maybe i couldn't read hosts? otherwise I have no idea what it was D:")
+        print(e)
+
+
+def run_setup():
+    if platform.system() == 'Darwin':
+        hostOS = OStypes["mac"]
+        print('MAC found!')
+        mac_setup(hostOS)
+    elif platform.system() == 'Windows':
+        hostOS = OStypes["windows"]
+        print('WINDOWS found!')
+        windows_setup(hostOS)
+    elif platform.system() == 'Linux':
+        hostOS = OStypes["linux"]
+        print('LINUX found!')
+        linux_setup(hostOS)
+    else:
+        print("Could not detect operating system. Maybe you're using")
+        print('something other than windows, mac, or linux?')
+
 
 print('---------------------------------------------------------------------------------------------------')
-print('| Welcome to aimmo! This script should make your life alil easier, just be kind if it doesnt work |')
+print('| Welcome to AI:MMO! This script should make your life alil easier, this script should get the    |')
+print('| various requirements for AI:MMO and set them up for you. Just be kind if it doesnt work         |')
+print('| work and please ask another member of the team for assistance.                                  |')
 print('| You may be asked to enter your password during this setup                                       |')
 print('---------------------------------------------------------------------------------------------------')
 
-if hostOS == OStypes["mac"]:
-    """
-    This executes the sequence of shell commands needed in order to set up aimmo. At present if changes are made
-    to the setup process or versions (such as minikube version) changes, then it will need to be updated manually.
-    In future it would be nice to have it automatically find the version we need at the time.
-
-    It would also be nice to implement the ability to automate getting the unity package, however this will require
-    selenium and a good amount of thought put into it.
-
-    Note needs homebrew pre-installed in order to run, will let the user know if they don't have it.
-    """
-    try:
-        result = _cmd('brew -v')
-        print('Homebrew Found...')
-        print(result.stdout)
-
-        try:
-            print('Installing Yarn...')
-            result = _cmd('brew install yarn')
-
-            print('Installing pipenv...')
-            result = _cmd('brew install pipenv')
-
-            print('Running "pipenv install"...')
-            result = _cmd('pipenv install')
-
-            print('Installing Docker...')
-            result = _cmd('brew cask install docker')
-
-            print('Installing Virtualbox...')
-            result = _cmd('brew cask install virtualbox')
-
-            print('Setting up frontend dependencies...')
-            result = _cmd('cd ./game_frontend | yarn')
-
-            print('Installing minikube...')
-            result = _cmd('curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-darwin-amd64')
-            result = _cmd('chmod +x minikube')
-            result = _cmd('sudo mv minikube /usr/local/bin/')
-
-            print('Installing Kubernetes...')
-            result = _cmd('curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/darwin/amd64/kubectl')
-            result = _cmd('chmod +x kubectl')
-            result = _cmd('sudo mv kubectl /usr/local/bin/')
-
-            print('adding aimmo to /etc/hosts...')
-            result = _cmd("sudo sh -c 'echo 192.168.99.100 local.aimmo.codeforlife.education >> /etc/hosts'")
-
-            print('---------------------------------------------------------------------------------------------------')
-            print('| You now need to get the unity package from the aimmo-unity repo, place it in aimmo/static/unity |')
-            print('| Also, just open up docker to finalize the install for it, then you can run aimmo.               |')
-            print('---------------------------------------------------------------------------------------------------')
-
-        except CalledProcessError as e:
-            print('A command has return an exit code != 0, so something has gone wrong.')
-        except OSError as e:
-            print("Tried to execute a command that didn't exist.")
-            print(result.stderr)
-        except ValueError as e:
-            print('Tried to execute a command with invalid arguments')
-            print(result.stderr)
-
-    except Exception as e:
-        print('Something went wrong :s, check if Homebrew is installed correctly.')
-        print("If it's not that, then something went wrong during the script unexpectedly,")
-        print("don't be alarmed, you may have to just try the manual setup. Sorry :(")
-        print(result.stderr)
+while not answered:
+    choice = raw_input('Do you want to continue? [y/n]').lower()
+    if choice in valid:
+        answer = valid[choice]
+        answered = True
+    else:
+        print("Please answer 'yes' or 'no' ('y' or 'n').")
+    if answer:
+        run_setup()
+    else:
+        print('Okay, no problem! ^_^')
 
 
-elif hostOS == OStypes["windows"]:
-    pass
-elif hostOS == OStypes["linux"]:
-    pass
-else:
-    print("Could not detect operating system/ it looks like you're using")
-    print('something other then windows, mac, or linux. Y u do dis?')

--- a/aimmo-setup.py
+++ b/aimmo-setup.py
@@ -5,6 +5,7 @@ import shlex
 
 from subprocess import PIPE, CalledProcessError
 
+
 class Result:
     '''
     Blank object used to store the result of a command run by Popen, do not use this
@@ -19,7 +20,7 @@ def _cmd(command):
     Takes in a command/subprocess, runs it, then returns an object containing all
     output from the process. DO NOT USE outside of the aimmo-setup script, and DO NOT INCLUDE
     in any release build, as this function is able to run bash scripts, will sudo access if
-    specified. 
+    specified.
     '''
     result = Result()
 
@@ -60,7 +61,7 @@ elif platform.system() == 'Linux':
     print('LINUX found!')
 
 print('---------------------------------------------------------------------------------------------------')
-print('| Welcome to aimmo! This script should make your life alil easier, just be kind if it doesnt work |') 
+print('| Welcome to aimmo! This script should make your life alil easier, just be kind if it doesnt work |')
 print('| You may be asked to enter your password during this setup                                       |')
 print('---------------------------------------------------------------------------------------------------')
 
@@ -121,10 +122,10 @@ if hostOS == OStypes["mac"]:
             print('A command has return an exit code != 0, so something has gone wrong.')
         except OSError as e:
             print("Tried to execute a command that didn't exist.")
-            print result.stderr
+            print(result.stderr)
         except ValueError as e:
             print('Tried to execute a command with invalid arguments')
-            print result.stderr
+            print(result.stderr)
 
     except Exception as e:
         print('Something went wrong :s, check if Homebrew is installed correctly.')

--- a/aimmo-setup.py
+++ b/aimmo-setup.py
@@ -1,0 +1,135 @@
+import os
+import platform
+import subprocess
+import shlex
+
+from subprocess import PIPE, CalledProcessError
+
+class Result:
+    pass
+
+def cmd(command):
+    '''
+    This takes in a command you wish to run, as a string, and excecutes it for you. This will work for commands run
+    on Linux, Mac, and Windows. 
+    '''
+    result = Result()
+
+    p = subprocess.Popen(shlex.split(command), stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    (stdout, stderr) = p.communicate()
+
+    result.exit_code = p.returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    result.command = command
+
+    if p.returncode != 0:
+        print 'Error executing command [%s]' % command
+        print 'stderr: [%s]' % stderr
+        print 'stdout: [%s]' % stdout
+        raise CalledProcessError
+
+    return result 
+
+# First we find and store the OS we are currently on, 0 if we didn't figure it out
+# Although if you're not using one the options above for development what are you doing with your life.
+hostOS = 0
+OStypes = {
+    "mac": 1,
+    "windows": 2,
+    "linux": 3
+}
+
+if platform.system() == 'Darwin':
+    hostOS = OStypes["mac"]
+    print 'MAC found!'
+elif platform.system() == 'Windows':
+    hostOS = OStypes["windows"]
+    print 'WINDOWS found!'
+elif platform.system() == 'Linux':
+    hostOS = OStypes["linux"]
+    print 'LINUX found!'
+
+print '---------------------------------------------------------------------------------------------------'
+print '| Welcome to aimmo! This script should make your life alil easier, just be kind if it doesnt work |'        
+print '---------------------------------------------------------------------------------------------------'
+print '| You may be asked to enter your password during this setup                                       |'
+print '---------------------------------------------------------------------------------------------------'
+
+if hostOS == OStypes["mac"]:
+    """
+    This executes the sequence of shell commands needed in order to set up aimmo. At present if changes are made
+    to the setup process or versions (such as minikube version) changes, then it will need to be updated manually.
+    In future it would be nice to have it automatically find the version we need at the time.
+
+    It would also be nice to implement the ability to automate getting the unity package, however this will require
+    selenium and a good amount of thought put into it.
+
+    Note needs homebrew pre-installed in order to run, will let the user know if they don't have it.
+    """
+    try:
+        result = cmd('brew -v')
+        print 'Homebrew Found...'
+        print result.stdout
+
+        try:
+            print 'Installing Yarn...'
+            result = cmd('brew install yarn')
+
+            print 'Installing pipenv...'
+            result = cmd('brew install pipenv')
+
+            print 'Running "pipenv install"...'
+            result = cmd('pipenv install')
+            
+            print 'Installing Docker...'
+            result = cmd('brew cask install docker')
+
+            print 'Installing Virtualbox...'
+            result = cmd('brew cask install docker')
+        
+            print 'Setting up frontend dependencies...'
+            result = cmd('cd ./game_frontend')
+            result = cmd('yarn')
+            result = cmd('cd ..')
+            
+            print 'Installing minikube...'
+            result = cmd('curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-darwin-amd64')
+            result = cmd('chmod +x minikube')
+            result = cmd('sudo mv minikube /usr/local/bin/')
+
+            print 'Installing Kubernetes...'
+            result = cmd('curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/darwin/amd64/kubectl')
+            result = cmd('chmod +x kubectl')
+            result = cmd('sudo mv kubectl /usr/local/bin/')
+
+            print 'adding aimmo to /etc/hosts...'
+            result = cmd('sudo echo "192.168.99.100 local.aimmo.codeforlife.education" >> /etc/hosts')
+
+            print '---------------------------------------------------------------------------------------------------'
+            print '| You now need to get the unity package from the aimmo-unity repo, place it in aimmo/static/unity |' 
+            print '| Follow the rest of the instructions on the readme to start up aimmo!                            |'        
+            print '---------------------------------------------------------------------------------------------------'
+            
+        except CalledProcessError as e:
+            print 'A command has return an exit code != 0, so something has gone wrong.'
+        except OSError as e:
+            print "Tried to execute a command that didn't exist."
+            print result.stderr
+        except ValueError as e:
+            print 'Tried to execute a command with invalid arguments'
+            print result.stderr
+
+    except Exception as e:
+        print 'Something went wrong when checking homebrew, has it been'
+        print 'installed properly?'
+        print result.stderr
+
+    
+elif hostOS == OStypes["windows"]:
+    pass
+elif hostOS == OStypes["linux"]:
+    pass
+else:
+    print "Could not detect operating system/ it looks like you're using"
+    print 'something other then windows, mac, or linux. Y u do dis?'

--- a/aimmo-setup.py
+++ b/aimmo-setup.py
@@ -15,7 +15,7 @@ def cmd(command):
     '''
     result = Result()
 
-    p = subprocess.Popen(shlex.split(command), stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    p = subprocess.Popen(command, stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True)
     (stdout, stderr) = p.communicate()
 
     result.exit_code = p.returncode
@@ -86,7 +86,7 @@ if hostOS == OStypes["mac"]:
             result = cmd('brew cask install docker')
 
             print 'Installing Virtualbox...'
-            result = cmd('brew cask install docker')
+            result = cmd('brew cask install virtualbox')
         
             print 'Setting up frontend dependencies...'
             result = cmd('cd ./game_frontend')
@@ -104,11 +104,11 @@ if hostOS == OStypes["mac"]:
             result = cmd('sudo mv kubectl /usr/local/bin/')
 
             print 'adding aimmo to /etc/hosts...'
-            result = cmd('sudo echo "192.168.99.100 local.aimmo.codeforlife.education" >> /etc/hosts')
+            result = cmd("sudo sh -c 'echo 192.168.99.100 local.aimmo.codeforlife.education >> /etc/hosts'")
 
             print '---------------------------------------------------------------------------------------------------'
             print '| You now need to get the unity package from the aimmo-unity repo, place it in aimmo/static/unity |' 
-            print '| Follow the rest of the instructions on the readme to start up aimmo!                            |'        
+            print '| Also, just open up docker to finalize the install for it, then you can run aimmo.               |'        
             print '---------------------------------------------------------------------------------------------------'
             
         except CalledProcessError as e:
@@ -121,8 +121,9 @@ if hostOS == OStypes["mac"]:
             print result.stderr
 
     except Exception as e:
-        print 'Something went wrong when checking homebrew, has it been'
-        print 'installed properly?'
+        print 'Something went wrong :s, check if Homebrew is installed correctly.'
+        print "If it's not that then something went wrong during the script unexpectedly,"
+        print "don't be alarmed, you may have to just try the manual setup. Sorry :("
         print result.stderr
 
     


### PR DESCRIPTION
Created the basic structure of the setup script and implemented the setup for mac. To use the script simply run `python aimmo-setup.py` from the aimmo root, it will then go through the process of setting up aimmo, then all you need to do is get the unity package, and open up docker to finalise it's setup. The script itself will inform the user when/how it fails if it does. A common issue i found when running this was running setting up the fronend using `yarn`, it didn't always run the command properly, i will however look into making this section more reliable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/822)
<!-- Reviewable:end -->
