### PR TITLE
replace handle_turn with next_turn

### DIFF
--- a/aimmo-game-worker/avatar_runner.py
+++ b/aimmo-game-worker/avatar_runner.py
@@ -157,7 +157,11 @@ class AvatarRunner(object):
 
     def decide_action(self, world_map, avatar_state):
         try:
-            action = self.avatar.handle_turn(world_map, avatar_state)
+            try:
+                action = self.avatar.handle_turn(world_map, avatar_state)
+            except AttributeError:
+                action = self.avatar.next_turn(world_map, avatar_state)
+
             if not isinstance(action, Action):
                 raise InvalidActionException(action)
             return action.serialise()

--- a/aimmo-game-worker/tests/test_avatar_runner.py
+++ b/aimmo-game-worker/tests/test_avatar_runner.py
@@ -14,7 +14,7 @@ WEST = {'x': -1, 'y': 0}
 class TestAvatarRunner(TestCase):
     def test_runner_does_not_crash_on_code_errors(self):
         avatar = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
                             assert False'''
 
         runner = AvatarRunner()
@@ -23,12 +23,12 @@ class TestAvatarRunner(TestCase):
 
     def test_runner_updates_code_on_change(self):
         avatar1 = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
                             
                             return MoveAction(direction.EAST)
                   '''
         avatar2 = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
                             
                             return MoveAction(direction.WEST)
                   '''
@@ -43,12 +43,12 @@ class TestAvatarRunner(TestCase):
 
     def test_update_code_flag_simple(self):
         avatar1 = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
                             
                             return MoveAction(direction.NORTH)
                   '''
         avatar2 = '''class Avatar:
-                                def handle_turn(self, world_map, avatar_state):
+                                def next_turn(self, world_map, avatar_state):
 
                                     return MoveAction(direction.SOUTH)
                   '''
@@ -75,7 +75,7 @@ class TestAvatarRunner(TestCase):
 
     def test_invalid_action_exception(self):
         avatar = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
                         
                             new_dir = random.choice(direction.ALL_DIRECTIONS)
                   '''
@@ -86,7 +86,7 @@ class TestAvatarRunner(TestCase):
 
     def test_does_not_update_with_imports(self):
         avatar = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
                             import os
                             return MoveAction(random.choice(direction.ALL_DIRECTIONS))
                   '''
@@ -97,14 +97,14 @@ class TestAvatarRunner(TestCase):
 
     def test_updated_successful(self):
         avatar_ok = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
                             
                             return MoveAction(direction.NORTH)
 
                     '''
 
         avatar_syntax_error = '''class Avatar:
-                                    def handle_turn(self, world_map, avatar_state):
+                                    def next_turn(self, world_map, avatar_state):
                                         
                                         return MoveAction(direction.NORTH
 
@@ -113,7 +113,7 @@ class TestAvatarRunner(TestCase):
         avatar_bad_constructor = '''class Avatar:
                                             def __init__(self):
                                                 return 1 + 'foo'
-                                            def handle_turn(self, world_map, avatar_state):
+                                            def next_turn(self, world_map, avatar_state):
 
                                                 return MoveAction(direction.NORTH)
                                   '''
@@ -130,7 +130,7 @@ class TestAvatarRunner(TestCase):
 
     def test_updates_with_for_loop(self):
         avatar = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
                             x = 0
                             for x in range(5):
                                 x = x + 1
@@ -144,7 +144,7 @@ class TestAvatarRunner(TestCase):
 
     def test_updates_with_inplace_operator(self):
         avatar = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
                             x = 0
                             x += 2
                                 
@@ -156,7 +156,7 @@ class TestAvatarRunner(TestCase):
 
     def test_runtime_error_contains_only_user_traceback(self):
         avatar = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
                             
                             1 + 'foo'
 
@@ -168,7 +168,7 @@ class TestAvatarRunner(TestCase):
 
     def test_syntax_error_contains_only_user_traceback(self):
         avatar = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
 
                             return MoveAction(direction.NORTH))))
                             
@@ -179,13 +179,13 @@ class TestAvatarRunner(TestCase):
 
     def test_invalid_action_exception_contains_only_user_traceback(self):
         avatar1 = '''class Avatar
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
 
                             return None
                             
                  '''
         avatar2 = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
 
                             return 1
                             
@@ -198,7 +198,7 @@ class TestAvatarRunner(TestCase):
 
     def test_print_collector_outputs_logs(self):
         avatar = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
                             print('I AM A PRINT STATEMENT')
                             return MoveAction(direction.NORTH)
                             
@@ -210,7 +210,7 @@ class TestAvatarRunner(TestCase):
 
     def test_print_collector_outputs_multiple_prints(self):
         avatar = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
                             print('I AM A PRINT STATEMENT')
                             print('I AM ALSO A PRINT STATEMENT')
                             return MoveAction(direction.NORTH)
@@ -223,7 +223,7 @@ class TestAvatarRunner(TestCase):
 
     def test_print_collector_outputs_prints_from_different_scopes(self):
         avatar = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
                             print('I AM NOT A NESTED PRINT')
                             self.foo()
                             return MoveAction(direction.NORTH)
@@ -239,7 +239,7 @@ class TestAvatarRunner(TestCase):
 
     def test_print_collector_prints_output_and_runtime_error_if_exists(self):
         avatar = '''class Avatar:
-                        def handle_turn(self, world_map, avatar_state):
+                        def next_turn(self, world_map, avatar_state):
                             print('THIS CODE IS BROKEN')
                             return None
                  '''

--- a/aimmo-game/tests/test_simulation/dummy_avatar.py
+++ b/aimmo-game/tests/test_simulation/dummy_avatar.py
@@ -23,7 +23,7 @@ class DummyAvatar(AvatarWrapper):
     def decide_action(self, worker_data):
         raise NotImplementedError()
 
-    def handle_turn(self, world_map=None, avatar_state=None):
+    def next_turn(self, world_map=None, avatar_state=None):
         raise NotImplementedError()
 
     def add_event(self, event):
@@ -50,7 +50,7 @@ class LiveDummy(DummyAvatar):
         super(LiveDummy, self).__init__(player_id, initial_location)
 
     def decide_action(self, worker_data):
-        self._action = self.handle_turn()
+        self._action = self.next_turn()
         return True
 
 
@@ -63,10 +63,10 @@ class DeadDummy(DummyAvatar):
         super(DeadDummy, self).__init__(player_id, initial_location)
 
     def decide_action(self, worker_data):
-        self._action = self.handle_turn()
+        self._action = self.next_turn()
         return False
 
-    def handle_turn(self, world_map=None, avatar_state=None):
+    def next_turn(self, world_map=None, avatar_state=None):
         return WaitAction(self)
 
 
@@ -74,7 +74,7 @@ class WaitDummy(LiveDummy):
     """
     Avatar that always waits.
     """
-    def handle_turn(self, world_map=None, avatar_state=None):
+    def next_turn(self, world_map=None, avatar_state=None):
         return WaitAction(self)
 
 
@@ -86,7 +86,7 @@ class MoveDummy(LiveDummy):
         super(MoveDummy, self).__init__(player_id, initial_location)
         self._direction = direction
 
-    def handle_turn(self, world_map=None, avatar_state=None):
+    def next_turn(self, world_map=None, avatar_state=None):
         return MoveAction(self, self._direction.dict)
 
 

--- a/aimmo-game/tests/test_simulation/mock_communicator.py
+++ b/aimmo-game/tests/test_simulation/mock_communicator.py
@@ -8,7 +8,7 @@ class MockCommunicator(object):
                     {
                         "id": 1,
                         "code": "class Avatar(object):\n"
-                                "    def handle_turn(self, world_view, events):\n"
+                                "    def next_turn(self, world_view, events):\n"
                                 "        from simulation.action import WaitAction\n"
                                 "        return WaitAction()\n"
                     },
@@ -16,7 +16,7 @@ class MockCommunicator(object):
                     {
                         "id": 2,
                         "code": "class Avatar(object):\n"
-                                "    def handle_turn(self, world_view, events):\n"
+                                "    def next_turn(self, world_view, events):\n"
                                 "        from simulation.action import WaitAction\n"
                                 "        return WaitAction()\n"
                     },

--- a/aimmo/avatar_examples/attacking_avatar.py
+++ b/aimmo/avatar_examples/attacking_avatar.py
@@ -1,5 +1,5 @@
 class Avatar:
-    def handle_turn(self, world_state, avatar_state):
+    def next_turn(self, world_state, avatar_state):
         self.avatar_state = avatar_state
         self.location = self.avatar_state.location
 

--- a/aimmo/avatar_examples/health_seeker_avatar.py
+++ b/aimmo/avatar_examples/health_seeker_avatar.py
@@ -1,5 +1,5 @@
 class Avatar:
-    def handle_turn(self, world_state, avatar_state):
+    def next_turn(self, world_state, avatar_state):
         self.world_state = world_state
         self.avatar_state = avatar_state
 

--- a/aimmo/avatar_examples/simple_avatar.py
+++ b/aimmo/avatar_examples/simple_avatar.py
@@ -1,4 +1,3 @@
 class Avatar:
-    def handle_turn(self, world_state, avatar_state):
-        new_dir = random.choice(direction.ALL_DIRECTIONS)
-        return MoveAction(new_dir)
+    def next_turn(self, world_state, avatar_state):
+        return MoveAction(direction.NORTH)

--- a/aimmo/avatar_examples/winner_avatar.py
+++ b/aimmo/avatar_examples/winner_avatar.py
@@ -1,5 +1,5 @@
 class Avatar:
-    def handle_turn(self, world_state, avatar_state):
+    def next_turn(self, world_state, avatar_state):
         self.world_state = world_state
         self.avatar_state = avatar_state
 

--- a/docs/architecture/workers/README.md
+++ b/docs/architecture/workers/README.md
@@ -47,13 +47,13 @@ global worker_avatar
 worker_avatar = Avatar(**options)
 ```
 
-The service assumes the user's `Avatar` class implements the method `handle_turn` and acts accordingly:
+The service assumes the user's `Avatar` class implements the method `next_turn` and acts accordingly:
 
 ```python
 @app.route('/turn/', methods=['POST'])
 def process_turn():
    [...]
-   action = worker_avatar.handle_turn(avatar_state, world_map)
+   action = worker_avatar.next_turn(avatar_state, world_map)
    return flask.jsonify(action=action.serialise())
 ```
 

--- a/docs/testing/test-plan.md
+++ b/docs/testing/test-plan.md
@@ -29,7 +29,7 @@
 
 ```
 class Avatar(object):
-    def handle_turn(self, world_view, events):
+    def next_turn(self, world_view, events):
         from simulation.action import MoveAction
         from simulation.direction import ALL_DIRECTIONS
         import random


### PR DESCRIPTION
Default code now looks like this:
```python
class Avatar:
    def next_turn(self, world_state, avatar_state):
        return MoveAction(direction.NORTH)
```
as per issue requirements. I kept the functionality for the original handle_turn method as well so existing games will still function for now as it was a relatively simple tweak to the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/962)
<!-- Reviewable:end -->
