### PR TITLE
fix: removed unity instructions from docs

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,7 +10,7 @@ The following UML diagram is intended as a rough overview of the project:
 
 [The UI (`aimmo` directory)](ui/README.md) 
 
-A Django app used for the front-end and database interaction. There are static Unity build files to render the game in browser.
+A Django app used for the front-end and database interaction. 
 
 [Games (`aimmo-game` directory)](games/README.md)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,7 +16,6 @@ This can be done either manually or using the setup script.
 
 * Run `python aimmo_setup.py` in the AI:MMO root directory. Then:
 * Open Docker to finalise the install process. (This will install the [latest release](https://www.docker.com/get-started))
-* Get the latest Unity bundle release from the [aimmo-unity](https://github.com/ocadotechnology/aimmo-unity) repo.
 * See [Useful information](#useful-information) for additional details about the script.
 
 #### Install manually:
@@ -34,7 +33,6 @@ The game should now be set up to run locally (If you ran the setup script, it wi
 * To install kubectl (Kubernetes), use:
 	* `curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/darwin/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/`
 * Alter your `/etc/hosts` file by adding the following line to the end of the file: `192.168.99.100 local.aimmo.codeforlife.education`. You may need to use sudo for this step as the file is protected.
-* Get the latest Unity bundle release from the [aimmo-unity](https://github.com/ocadotechnology/aimmo-unity) repo.
 * Follow the instructions for [deploying Portainer](https://portainer.io/install.html), to create a dashboard for your local docker containers.
 
 #### To run AI:MMO:
@@ -50,8 +48,7 @@ This can be done either manually or using the setup script.
 
 #### Install using the setup script:
 
-* Run `python aimmo_setup.py` in the AI:MMO root directory. Then:
-* Get the latest Unity bundle release from the [aimmo-unity](https://github.com/ocadotechnology/aimmo-unity) repo.
+* Run `python aimmo_setup.py` in the AI:MMO root directory.
 * See [Useful information](#useful-information) for additional details about the script.
 
 #### Install manually:
@@ -68,7 +65,6 @@ The game should now be set up to run locally (If you ran the setup script, it wi
 * Now run `sudo snap install kubectl --classic` to install kubectl ([Kubernetes](https://kubernetes.io/)).
 * To install [Docker](https://www.docker.com/), either use `sudo apt-get install docker-ce` to install a fixed version of the latest release, or follow the Ubuntu install instructions on the [Docker website](https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-using-the-repository).
 * Alter your `/etc/hosts` file by adding the following line to the end of the file: `192.168.99.100 local.aimmo.codeforlife.education`. You may need to use sudo for this step as the file is protected.
-* Get the latest Unity bundle release from the [aimmo-unity](https://github.com/ocadotechnology/aimmo-unity) repo.
 * Follow the instructions for [deploying Portainer](https://portainer.io/install.html), to create a dashboard for your local docker containers.
 
 #### To run AI:MMO:

--- a/game_frontend/README.md
+++ b/game_frontend/README.md
@@ -28,7 +28,7 @@ yarn
 
 ### Standalone
 
-It's possible to run the frontend by itself. To do so, run the command below in this folder. **Note:** the Unity WebGL build will not show in standalone mode and you will need to run the project with Django.
+It's possible to run the frontend by itself. To do so, run the command below in this folder.
 
 ```
 parcel index.html


### PR DESCRIPTION
Removed Unity build instructions from architecture README.md, usage.md and game-frontend README.md.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/1128)
<!-- Reviewable:end -->
