### PR TITLE
ci: fix check for deploying to dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ stages:
   - name: test
     if: NOT tag IS present
   - name: release
-    if: branch = master OR branch = development
+    if: (branch = master OR branch = development) AND (NOT type IN (pull_request))
   - name: deploy
     if: tag IS present AND (NOT type IN (pull_request))
   - name: Notify Semaphore

--- a/version_updater.py
+++ b/version_updater.py
@@ -11,8 +11,8 @@ parser.add_argument("TRAVIS_BRANCH", help="Name of the branch the build is on")
 args = parser.parse_args()
 version = __version__
 
-if args.DEPLOY_TO_DEV:
-    version = __version__ + "dev" + args.TRAVIS_BUILD_NUMBER
+if args.DEPLOY_TO_DEV == "true":
+    version = __version__ + ".dev" + args.TRAVIS_BUILD_NUMBER
 else:
     BRANCH = args.TRAVIS_BRANCH
 


### PR DESCRIPTION
The last attempt at creating a tag appended the version with 'dev' because the check on the boolean `DEPLOY_TO_DEV` just checked if the env var existed, as opposed to checking that it equalled true.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/1137)
<!-- Reviewable:end -->
