### PR TITLE
fix: remove 'v' from Travis tag in docker commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,19 +159,19 @@ jobs:
         - popd
     - name: "Build and push game image"
       script:
-        - docker build --no-cache -t ocadotechnology/aimmo-game:${TRAVIS_TAG} aimmo-game/
+        - docker build --no-cache -t ocadotechnology/aimmo-game:${TRAVIS_TAG:1} aimmo-game/
         - docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD}
-        - docker push ocadotechnology/aimmo-game:${TRAVIS_TAG}
+        - docker push ocadotechnology/aimmo-game:${TRAVIS_TAG:1}
     - name: "Build and push game creator image"
       script:
-        - docker build --no-cache -t ocadotechnology/aimmo-game-creator:${TRAVIS_TAG} aimmo-game-creator/
+        - docker build --no-cache -t ocadotechnology/aimmo-game-creator:${TRAVIS_TAG:1} aimmo-game-creator/
         - docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD}
-        - docker push ocadotechnology/aimmo-game-creator:${TRAVIS_TAG}
+        - docker push ocadotechnology/aimmo-game-creator:${TRAVIS_TAG:1}
     - name: "Build and push game worker image"
       script:
-        - docker build --no-cache -t ocadotechnology/aimmo-game-worker:${TRAVIS_TAG} aimmo-game-worker/
+        - docker build --no-cache -t ocadotechnology/aimmo-game-worker:${TRAVIS_TAG:1} aimmo-game-worker/
         - docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD}
-        - docker push ocadotechnology/aimmo-game-worker:${TRAVIS_TAG}
+        - docker push ocadotechnology/aimmo-game-worker:${TRAVIS_TAG:1}
     - stage: Notify Semaphore (Staging)
       script:
         - "curl -d POST -v https://semaphoreci.com/api/v1/projects/${SEMAPHORE_PROJECT_ID}/master/build?auth_token=${SEMAPHORE_API_AUTH}"


### PR DESCRIPTION
## Description
There was a problem whereby the docker images on staging and dev could not be pulled properly. It seemed like this was because of the version tag being different on DockerHub and in Pypi: Travis built and pushed a tag on DockerHub with a 'v' but the images that were being pulled from the creator for example depended on the version on Pypi which doesn't have a 'v'.

This PR should fix this by making Travis push tags on DockerHub without the 'v' which should match the Pypi versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/1152)
<!-- Reviewable:end -->
