### PR TITLE
fix: add, update and remove workers concurrently

### DIFF
--- a/aimmo-game/activity_monitor.py
+++ b/aimmo-game/activity_monitor.py
@@ -48,8 +48,9 @@ class ActivityMonitor:
             )
 
     def _stop_timer(self):
-        LOGGER.info("Cancelling timer!")
-        self.timer.cancel()
+        if not self.timer.cancelled():
+            LOGGER.info("Cancelling timer!")
+            self.timer.cancel()
 
     @property
     def active_users(self):

--- a/aimmo-game/service.py
+++ b/aimmo-game/service.py
@@ -150,7 +150,9 @@ class GameAPI(object):
             await self._send_game_state(sid)
             await self._send_logs(sid)
         except KeyError:
-            LOGGER.error(f"Failed to send updates. No worker for player in session {sid}")
+            LOGGER.error(
+                f"Failed to send updates. No worker for player in session {sid}"
+            )
 
     async def send_updates_to_all(self):
         try:
@@ -197,7 +199,9 @@ class GameAPI(object):
         session_data = await self.socketio_server.get_session(sid)
         worker = self.worker_manager.player_id_to_worker[session_data["id"]]
         if worker.ready:
-            await self.socketio_server.emit("game-state", serialized_game_state, room=sid)
+            await self.socketio_server.emit(
+                "game-state", serialized_game_state, room=sid
+            )
 
     async def _send_have_avatars_code_updated(self, sid):
         session_data = await self.socketio_server.get_session(sid)

--- a/aimmo-game/simulation/game_runner.py
+++ b/aimmo-game/simulation/game_runner.py
@@ -91,6 +91,7 @@ class GameRunner:
 
     async def run(self):
         while True:
+            LOGGER.info(f"Starting turn {self.game_state.turn_count}")
             turn = asyncio.ensure_future(self.update())
             await asyncio.sleep(TURN_TIME)
             await turn

--- a/aimmo-game/simulation/workers/worker.py
+++ b/aimmo-game/simulation/workers/worker.py
@@ -1,7 +1,7 @@
 import logging
 from asyncio import CancelledError
 
-from aiohttp import ClientSession, ClientResponseError, ServerDisconnectedError, ClientOSError
+from aiohttp import ClientSession, ClientResponseError, ServerDisconnectedError
 
 LOGGER = logging.getLogger(__name__)
 

--- a/aimmo-game/simulation/workers/worker.py
+++ b/aimmo-game/simulation/workers/worker.py
@@ -29,7 +29,7 @@ class Worker(object):
         raise NotImplementedError
 
     async def fetch_data(self, state_view):
-        if self.code == None:
+        if self.code is None:
             self._set_defaults()
             return
         try:

--- a/aimmo-game/simulation/workers/worker.py
+++ b/aimmo-game/simulation/workers/worker.py
@@ -30,6 +30,7 @@ class Worker(object):
 
     async def fetch_data(self, state_view):
         if self.code == None:
+            self._set_defaults()
             return
         try:
             async with ClientSession(raise_for_status=True) as session:

--- a/aimmo-game/simulation/workers/worker.py
+++ b/aimmo-game/simulation/workers/worker.py
@@ -1,7 +1,7 @@
 import logging
 from asyncio import CancelledError
 
-from aiohttp import ClientResponseError, ClientSession
+from aiohttp import ClientSession, ClientResponseError, ServerDisconnectedError, ClientOSError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +29,8 @@ class Worker(object):
         raise NotImplementedError
 
     async def fetch_data(self, state_view):
+        if self.code == None:
+            return
         try:
             async with ClientSession(raise_for_status=True) as session:
                 code_and_options = {"code": self.code, "options": {}, "state": None}
@@ -39,7 +41,7 @@ class Worker(object):
                 self.log = data["log"]
                 self.has_code_updated = data["avatar_updated"]
                 self.ready = True
-        except ClientResponseError:
+        except (ClientResponseError, ServerDisconnectedError):
             LOGGER.info("Could not connect to worker, probably not ready yet")
             self._set_defaults()
         except CancelledError as e:

--- a/aimmo-game/tests/test_simulation/concrete_worker.py
+++ b/aimmo-game/tests/test_simulation/concrete_worker.py
@@ -4,6 +4,10 @@ from simulation.workers.worker import Worker
 class ConcreteWorker(Worker):
     def __init__(self, *args, **kwargs):
         super(ConcreteWorker, self).__init__(*args, **kwargs)
+        self.code = """
+def next_turn(world_state, avatar_state):
+    return MoveAction(direction.NORTH)
+"""
 
     def _create_worker(self):
         return "http://test"

--- a/aimmo-game/tests/test_simulation/mock_worker_manager.py
+++ b/aimmo-game/tests/test_simulation/mock_worker_manager.py
@@ -10,17 +10,17 @@ class MockWorkerManager(WorkerManager):
         super(MockWorkerManager, self).__init__(*args, **kwargs)
         self.worker_class = ConcreteWorker
 
-    async def add_new_worker(self, player_id):
+    def add_new_worker(self, player_id):
         self.final_workers.add(player_id)
-        await super(MockWorkerManager, self).add_new_worker(player_id)
+        super(MockWorkerManager, self).add_new_worker(player_id)
 
-    async def delete_worker(self, player_id):
+    def delete_worker(self, player_id):
         try:
             self.final_workers.remove(player_id)
         except KeyError:
             pass
-        await super(MockWorkerManager, self).delete_worker(player_id)
+        super(MockWorkerManager, self).delete_worker(player_id)
 
-    async def update_code(self, user):
+    def update_code(self, user):
         self.updated_workers.append(user["id"])
-        await super(MockWorkerManager, self).update_code(user)
+        super(MockWorkerManager, self).update_code(user)

--- a/aimmo-game/tests/test_simulation/workers/test_local_worker.py
+++ b/aimmo-game/tests/test_simulation/workers/test_local_worker.py
@@ -6,23 +6,21 @@ from simulation.workers.local_worker import LocalWorker
 from simulation.worker_manager import WorkerManager
 
 import pytest
-import asyncio
 
 
-@pytest.mark.asyncio
-async def test_local_worker_ports_do_not_conflict(mocker):
+def test_local_worker_ports_do_not_conflict(mocker):
     mocker.patch("docker.from_env")
     os.environ["GAME_ID"] = "1"
     LocalWorker._init_port_counter()
     worker_manager1 = WorkerManager()
-    await worker_manager1.add_new_worker(1)
+    worker_manager1.add_new_worker(1)
     local_worker1 = worker_manager1.player_id_to_worker[1]
     url1 = urlparse(local_worker1.url)
 
     os.environ["GAME_ID"] = "2"
     LocalWorker._init_port_counter()
     worker_manager2 = WorkerManager()
-    await worker_manager2.add_new_worker(1)
+    worker_manager2.add_new_worker(1)
     local_worker2 = worker_manager2.player_id_to_worker[1]
     url2 = urlparse(local_worker2.url)
 
@@ -30,14 +28,13 @@ async def test_local_worker_ports_do_not_conflict(mocker):
     assert url2.port == 21989
 
 
-@pytest.mark.asyncio
-async def test_local_worker_in_the_same_game_do_not_have_port_conflicts(mocker):
+def test_local_worker_in_the_same_game_do_not_have_port_conflicts(mocker):
     mocker.patch("docker.from_env")
     os.environ["GAME_ID"] = "1"
     LocalWorker._init_port_counter()
     worker_manager = WorkerManager()
-    await worker_manager.add_new_worker(1)
-    await worker_manager.add_new_worker(2)
+    worker_manager.add_new_worker(1)
+    worker_manager.add_new_worker(2)
     local_worker1 = worker_manager.player_id_to_worker[1]
     local_worker2 = worker_manager.player_id_to_worker[2]
 

--- a/aimmo-game/tests/test_socketio.py
+++ b/aimmo-game/tests/test_socketio.py
@@ -68,7 +68,9 @@ def client(app, aiohttp_client, loop):
     return loop.run_until_complete(aiohttp_client(app))
 
 
-async def test_socketio_emit_called_when_worker_ready(game_api, socketio_server, client, loop):
+async def test_socketio_emit_called_when_worker_ready(
+    game_api, socketio_server, client, loop
+):
     socketio_client = socketio.AsyncClient(reconnection=False)
     mock_game_state_listener = mock.MagicMock()
 
@@ -77,7 +79,7 @@ async def test_socketio_emit_called_when_worker_ready(game_api, socketio_server,
     socketio_client.on("game-state", mock_game_state_listener)
 
     worker = game_api.worker_manager.player_id_to_worker[1]
-    worker.ready = True    
+    worker.ready = True
 
     await socketio_client.connect(
         f"http://{client.server.host}:{client.server.port}?avatar_id=1&EIO=3&transport=polling&t=MJhoMgb"
@@ -90,7 +92,10 @@ async def test_socketio_emit_called_when_worker_ready(game_api, socketio_server,
 
     mock_game_state_listener.assert_called_once()
 
-async def test_socketio_emit_not_called_if_worker_not_ready(game_api, socketio_server, client, loop):
+
+async def test_socketio_emit_not_called_if_worker_not_ready(
+    game_api, socketio_server, client, loop
+):
     socketio_client = socketio.AsyncClient(reconnection=False)
     mock_game_state_listener = mock.MagicMock()
 

--- a/aimmo-game/tests/test_socketio.py
+++ b/aimmo-game/tests/test_socketio.py
@@ -72,7 +72,7 @@ async def test_socketio_emit_called_when_worker_ready(game_api, socketio_server,
     socketio_client = socketio.AsyncClient(reconnection=False)
     mock_game_state_listener = mock.MagicMock()
 
-    await game_api.worker_manager.add_new_worker(1)
+    game_api.worker_manager.add_new_worker(1)
 
     socketio_client.on("game-state", mock_game_state_listener)
 
@@ -94,7 +94,7 @@ async def test_socketio_emit_not_called_if_worker_not_ready(game_api, socketio_s
     socketio_client = socketio.AsyncClient(reconnection=False)
     mock_game_state_listener = mock.MagicMock()
 
-    await game_api.worker_manager.add_new_worker(1)
+    game_api.worker_manager.add_new_worker(1)
 
     socketio_client.on("game-state", mock_game_state_listener)
 
@@ -117,7 +117,7 @@ async def test_send_updates_for_one_user(game_api, client, socketio_server, loop
     socketio_client = socketio.AsyncClient(reconnection=False)
     mock_log_listener = mock.MagicMock()
 
-    await game_api.worker_manager.add_new_worker(1)
+    game_api.worker_manager.add_new_worker(1)
 
     socketio_client.on("log", mock_log_listener)
 
@@ -143,7 +143,7 @@ async def test_no_logs_not_emitted(game_api, client, socketio_server, loop):
     socketio_client = socketio.AsyncClient(reconnection=False)
     mock_log_listener = mock.MagicMock()
 
-    await game_api.worker_manager.add_new_worker(1)
+    game_api.worker_manager.add_new_worker(1)
 
     socketio_client.on("log", mock_log_listener)
 
@@ -164,7 +164,7 @@ async def test_empty_logs_not_emitted(game_api, client, socketio_server, loop):
     socketio_client = socketio.AsyncClient(reconnection=False)
     mock_log_listener = mock.MagicMock()
 
-    await game_api.worker_manager.add_new_worker(1)
+    game_api.worker_manager.add_new_worker(1)
 
     socketio_client.on("log", mock_log_listener)
 
@@ -189,8 +189,8 @@ async def test_send_updates_for_multiple_users(game_api, client, socketio_server
     mock_log_listener = mock.MagicMock()
     mock_log_listener2 = mock.MagicMock()
 
-    await game_api.worker_manager.add_new_worker(1)
-    await game_api.worker_manager.add_new_worker(2)
+    game_api.worker_manager.add_new_worker(1)
+    game_api.worker_manager.add_new_worker(2)
 
     socketio_client.on("log", mock_log_listener)
     socketio_client2.on("log", mock_log_listener2)
@@ -226,7 +226,7 @@ async def test_send_code_changed_flag(game_api, client, socketio_server, loop):
     socketio_client = socketio.AsyncClient(reconnection=False)
     mock_avatar_updated_listener = mock.MagicMock()
 
-    await game_api.worker_manager.add_new_worker(1)
+    game_api.worker_manager.add_new_worker(1)
 
     socketio_client.on("feedback-avatar-updated", mock_avatar_updated_listener)
 
@@ -249,7 +249,7 @@ async def test_send_false_flag_not_sent(game_api, client, socketio_server, loop)
     socketio_client = socketio.AsyncClient(reconnection=False)
     mock_avatar_updated_listener = mock.MagicMock()
 
-    await game_api.worker_manager.add_new_worker(1)
+    game_api.worker_manager.add_new_worker(1)
 
     socketio_client.on("feedback-avatar-updated", mock_avatar_updated_listener)
 
@@ -271,7 +271,7 @@ async def test_send_false_flag_not_sent(game_api, client, socketio_server, loop)
 async def test_remove_session_id_on_disconnect(game_api, client, socketio_server, loop):
     socketio_client = socketio.AsyncClient(reconnection=False)
 
-    await game_api.worker_manager.add_new_worker(1)
+    game_api.worker_manager.add_new_worker(1)
 
     await socketio_client.connect(
         f"http://{client.server.host}:{client.server.port}?avatar_id=1&EIO=3&transport=polling&t=MJhoMgb"


### PR DESCRIPTION
By switching the `parallel_map` function to use asyncio, we lost the ability to execute the synchronous adding worker code concurrently. This PR reverts to how it was done before (using a `ThreadPoolExecutor`) and also includes some changes to make the log messages cleaner.


> **Note**
> As before, this still doesn't guarantee that the turn time will 2 seconds if adding workers takes longer than that. However, at least this way it is faster than before so that it is less noticeable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/1182)
<!-- Reviewable:end -->
