### PR TITLE
feat: Implement reset code button

### DIFF
--- a/game_frontend/src/components/ConsoleBar/__snapshots__/index.test.js.snap
+++ b/game_frontend/src/components/ConsoleBar/__snapshots__/index.test.js.snap
@@ -15,6 +15,11 @@ exports[`<ConsoleBar /> renders correctly 1`] = `
       Console Log
     </WithStyles(ForwardRef(Typography))>
   </styled.div>
+  <WithStyles(ForwardRef(Button))
+    variant="outlined"
+  >
+    Reset code
+  </WithStyles(ForwardRef(Button))>
   <WithStyles(ForwardRef(IconButton))
     size="small"
   >

--- a/game_frontend/src/components/ConsoleBar/index.js
+++ b/game_frontend/src/components/ConsoleBar/index.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import Toolbar from '@material-ui/core/Toolbar/Toolbar'
-import { Typography, IconButton } from '@material-ui/core'
+import { Typography, IconButton, Button } from '@material-ui/core'
 import ConsoleIcon from 'components/icons/Console'
 import ClearIcon from 'components/icons/Clear'
 import React, { Component } from 'react'
@@ -22,7 +22,8 @@ export const StyledConsoleIcon = styled(ConsoleIcon)`
 
 export default class ConsoleBar extends Component {
   static propTypes = {
-    clearConsoleClicked: PropTypes.func
+    clearConsoleClicked: PropTypes.func,
+    resetCodeClicked: PropTypes.func
   }
 
   render () {
@@ -36,6 +37,11 @@ export default class ConsoleBar extends Component {
           Console Log
           </Typography>
         </StyledConsoleTitle>
+        <Button
+          variant='outlined'
+          onClick={this.props.resetCodeClicked}>
+          Reset code
+        </Button>
         <IconButton
           size='small'
           onClick={this.props.clearConsoleClicked}>

--- a/game_frontend/src/containers/IDEConsole/index.js
+++ b/game_frontend/src/containers/IDEConsole/index.js
@@ -5,6 +5,7 @@ import LogEntries from 'components/LogEntries'
 import ConsoleBar from 'components/ConsoleBar'
 import { connect } from 'react-redux'
 import { actions } from 'redux/features/ConsoleLog'
+import { actions as editorActions } from 'redux/features/Editor'
 
 export const IDEConsoleSection = styled.section`
   grid-area: ide-console;
@@ -68,7 +69,7 @@ export class IDEConsole extends Component {
   render () {
     return (
       <IDEConsoleSection>
-        <ConsoleBar clearConsoleClicked={this.props.clearConsoleLogs} />
+        <ConsoleBar clearConsoleClicked={this.props.clearConsoleLogs} resetCodeClicked={this.props.resetCode} />
         <StyledConsole innerRef={ref => { this.consoleRef = ref }}>
           <LogEntries
             logs={this.props.logs}
@@ -84,7 +85,8 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = {
-  clearConsoleLogs: actions.clearConsoleLogs
+  clearConsoleLogs: actions.clearConsoleLogs,
+  resetCode: editorActions.resetCode
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(IDEConsole)

--- a/game_frontend/src/redux/features/Editor/actions.js
+++ b/game_frontend/src/redux/features/Editor/actions.js
@@ -36,6 +36,12 @@ const changeCode = code => (
   }
 )
 
+const resetCode = () => (
+  {
+    type: types.RESET_CODE
+  }
+)
+
 const keyPressed = code => (
   {
     type: types.KEY_PRESSED,
@@ -51,5 +57,6 @@ export default {
   postCodeRequest,
   postCodeReceived,
   changeCode,
-  keyPressed
+  keyPressed,
+  resetCode
 }

--- a/game_frontend/src/redux/features/Editor/epics.js
+++ b/game_frontend/src/redux/features/Editor/epics.js
@@ -44,6 +44,12 @@ const postCodeAnalyticsEpic = action$ =>
     mapTo(analyticActions.sendAnalyticsEvent('Kurono', 'Click', 'Run Code'))
   )
 
+const resetCodeAnalyticsEpic = action$ =>
+  action$.pipe(
+    ofType(types.RESET_CODE),
+    mapTo(analyticActions.sendAnalyticsEvent('Kurono', 'Click', 'Reset Code'))
+  )
+
 const changeCodeEpic = (action$, state$, dependencies, scheduler = backgroundScheduler) =>
   action$.pipe(
     ofType(types.KEY_PRESSED),
@@ -55,5 +61,6 @@ export default {
   getCodeEpic,
   postCodeEpic,
   changeCodeEpic,
-  postCodeAnalyticsEpic
+  postCodeAnalyticsEpic,
+  resetCodeAnalyticsEpic
 }

--- a/game_frontend/src/redux/features/Editor/reducers.js
+++ b/game_frontend/src/redux/features/Editor/reducers.js
@@ -3,7 +3,7 @@ import types from './types'
 import { gameTypes } from 'features/Game'
 import { RunCodeButtonStatus } from 'components/RunCodeButton'
 
-const DEFAULT_CODE = `def next_turn(world_state, avatar_state):
+export const DEFAULT_CODE = `def next_turn(world_state, avatar_state):
     return MoveAction(direction.NORTH)
 `
 

--- a/game_frontend/src/redux/features/Editor/reducers.js
+++ b/game_frontend/src/redux/features/Editor/reducers.js
@@ -2,10 +2,7 @@ import { combineReducers } from 'redux'
 import types from './types'
 import { gameTypes } from 'features/Game'
 import { RunCodeButtonStatus } from 'components/RunCodeButton'
-
-const DEFAULT_CODE = `def next_turn(world_state, avatar_state):
-    return MoveAction(direction.NORTH)
-`
+import { DEFAULT_CODE } from '../constants'
 
 const codeReducer = (state = {}, action) => {
   switch (action.type) {

--- a/game_frontend/src/redux/features/Editor/reducers.js
+++ b/game_frontend/src/redux/features/Editor/reducers.js
@@ -3,6 +3,10 @@ import types from './types'
 import { gameTypes } from 'features/Game'
 import { RunCodeButtonStatus } from 'components/RunCodeButton'
 
+const DEFAULT_CODE = `def next_turn(world_state, avatar_state):
+    return MoveAction(direction.NORTH)
+`
+
 const codeReducer = (state = {}, action) => {
   switch (action.type) {
     case types.GET_CODE_SUCCESS:
@@ -20,6 +24,11 @@ const codeReducer = (state = {}, action) => {
       return {
         ...state,
         codeOnServer: state.code
+      }
+    case types.RESET_CODE:
+      return {
+        ...state,
+        code: DEFAULT_CODE
       }
     default:
       return state

--- a/game_frontend/src/redux/features/Editor/reducers.js
+++ b/game_frontend/src/redux/features/Editor/reducers.js
@@ -3,7 +3,7 @@ import types from './types'
 import { gameTypes } from 'features/Game'
 import { RunCodeButtonStatus } from 'components/RunCodeButton'
 
-export const DEFAULT_CODE = `def next_turn(world_state, avatar_state):
+const DEFAULT_CODE = `def next_turn(world_state, avatar_state):
     return MoveAction(direction.NORTH)
 `
 

--- a/game_frontend/src/redux/features/Editor/reducers.test.js
+++ b/game_frontend/src/redux/features/Editor/reducers.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import editorReducer from './reducers'
+import editorReducer, { DEFAULT_CODE } from './reducers'
 import actions from './actions'
 import { actions as gameActions } from 'features/Game'
 import { RunCodeButtonStatus } from 'components/RunCodeButton'
@@ -72,5 +72,22 @@ describe('runCodeButtonReducer', () => {
 
     const action = gameActions.snackbarShown()
     expect(editorReducer({}, action)).toEqual(expectedState)
+  })
+})
+
+describe('resetCodeReducer', () => {
+  it('should reset the code the the initial code', () => {
+    const initialState = {
+      code: {},
+      runCodeButton: {}
+    }
+    const expectedState = {
+      code: {
+        code: DEFAULT_CODE
+      },
+      runCodeButton: {}
+    }
+    const action = actions.resetCode()
+    expect(editorReducer(initialState, action)).toEqual(expectedState)
   })
 })

--- a/game_frontend/src/redux/features/Editor/reducers.test.js
+++ b/game_frontend/src/redux/features/Editor/reducers.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import editorReducer, { DEFAULT_CODE } from './reducers'
+import editorReducer from './reducers'
 import actions from './actions'
 import { actions as gameActions } from 'features/Game'
 import { RunCodeButtonStatus } from 'components/RunCodeButton'
@@ -77,6 +77,9 @@ describe('runCodeButtonReducer', () => {
 
 describe('resetCodeReducer', () => {
   it('should reset the code the the initial code', () => {
+    const DEFAULT_CODE = `def next_turn(world_state, avatar_state):
+    return MoveAction(direction.NORTH)
+`
     const initialState = {
       code: {},
       runCodeButton: {}

--- a/game_frontend/src/redux/features/Editor/types.js
+++ b/game_frontend/src/redux/features/Editor/types.js
@@ -9,6 +9,8 @@ const POST_CODE_FAILURE = 'features/Editor/POST_CODE_FAILURE'
 const CHANGE_CODE = 'features/Editor/CHANGE_CODE'
 const KEY_PRESSED = 'features/Editor/KEY_PRESSED'
 
+const RESET_CODE = 'features/Editor/RESET_CODE'
+
 export default {
   GET_CODE_REQUEST,
   GET_CODE_SUCCESS,
@@ -17,5 +19,6 @@ export default {
   POST_CODE_SUCCESS,
   POST_CODE_FAILURE,
   CHANGE_CODE,
-  KEY_PRESSED
+  KEY_PRESSED,
+  RESET_CODE
 }

--- a/game_frontend/src/redux/features/constants.js
+++ b/game_frontend/src/redux/features/constants.js
@@ -1,0 +1,3 @@
+export const DEFAULT_CODE = `def next_turn(world_state, avatar_state):
+    return MoveAction(direction.NORTH)
+`


### PR DESCRIPTION
## Description

This PR implements the reset code button in Kurono.
This button resets the user's code to the default code when pressed.
This PR also includes a test and an analytics event for that button.

## Screenshot
![Kurono - Google Chrome_017](https://user-images.githubusercontent.com/33633200/73933702-eb874980-48d4-11ea-954d-28000e4a3128.png)

![Selection_018](https://user-images.githubusercontent.com/33633200/73933723-fb9f2900-48d4-11ea-948b-de5aceefedf1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/1248)
<!-- Reviewable:end -->
