### PR TITLE
fix: Stop loop on Exception in game turn

### DIFF
--- a/aimmo-game/simulation/game_runner.py
+++ b/aimmo-game/simulation/game_runner.py
@@ -87,18 +87,18 @@ class GameRunner:
 
     async def run(self):
         while True:
-            loop = asyncio.get_event_loop()
             LOGGER.info(f"Starting turn {self.game_state.turn_count}")
             turn = asyncio.ensure_future(self.update())
 
-            def callback(turn_future):
-                try:
-                    turn_future.result()
-                except Exception:
-                    LOGGER.error("Unexpected error")
-                    loop.stop()
-
-            turn.add_done_callback(callback)
+            turn.add_done_callback(self._get_task_result_or_stop_loop)
 
             await asyncio.sleep(TURN_TIME)
             await turn
+
+    def _get_task_result_or_stop_loop(self, task):
+        try:
+            task.result()
+        except Exception as e:
+            LOGGER.error(f"Unexpected error: {e}")
+            loop = asyncio.get_event_loop()
+            loop.stop()

--- a/aimmo-game/simulation/game_runner.py
+++ b/aimmo-game/simulation/game_runner.py
@@ -85,6 +85,14 @@ class GameRunner:
             self.game_state.avatar_manager.clear_all_avatar_logs()
             self.game_state.turn_count += 1
 
+    def _get_task_result_or_stop_loop(self, task):
+        try:
+            task.result()
+        except Exception as e:
+            LOGGER.error(f"Unexpected error, stopping game loop: {e}")
+            loop = asyncio.get_event_loop()
+            loop.stop()
+
     async def run(self):
         while True:
             LOGGER.info(f"Starting turn {self.game_state.turn_count}")
@@ -94,11 +102,3 @@ class GameRunner:
 
             await asyncio.sleep(TURN_TIME)
             await turn
-
-    def _get_task_result_or_stop_loop(self, task):
-        try:
-            task.result()
-        except Exception as e:
-            LOGGER.error(f"Unexpected error: {e}")
-            loop = asyncio.get_event_loop()
-            loop.stop()

--- a/aimmo-game/simulation/game_runner.py
+++ b/aimmo-game/simulation/game_runner.py
@@ -89,7 +89,7 @@ class GameRunner:
         try:
             task.result()
         except Exception as e:
-            LOGGER.error(f"Unexpected error, stopping game loop: {e}")
+            LOGGER.exception(f"Unexpected error, stopping game loop: {e}")
             loop = asyncio.get_event_loop()
             loop.stop()
 

--- a/aimmo-game/simulation/game_runner.py
+++ b/aimmo-game/simulation/game_runner.py
@@ -87,7 +87,18 @@ class GameRunner:
 
     async def run(self):
         while True:
+            loop = asyncio.get_event_loop()
             LOGGER.info(f"Starting turn {self.game_state.turn_count}")
             turn = asyncio.ensure_future(self.update())
+
+            def callback(turn_future):
+                try:
+                    turn_future.result()
+                except Exception:
+                    LOGGER.error("Unexpected error")
+                    loop.stop()
+
+            turn.add_done_callback(callback)
+
             await asyncio.sleep(TURN_TIME)
             await turn


### PR DESCRIPTION
This PR addresses the issue linked below by forcing the loop to crash in case of an Exception.

Two things we need to discuss:
- Should we keep this generic Exception catching or should we target a more specific Exception?
- What should the logger message say?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/1301)
<!-- Reviewable:end -->
