### PR TITLE
fix: Add include kwarg to find_packages

### DIFF
--- a/aimmo-game-worker/setup.py
+++ b/aimmo-game-worker/setup.py
@@ -17,7 +17,7 @@ def get_version():
 
 setup(
     name="aimmo-avatar-api",
-    packages=find_packages("simulation"),
+    packages=find_packages(include=["simulation"]),
     version=get_version(),
     include_package_data=True,
     tests_require=["httmock", "mock"],


### PR DESCRIPTION
Adding this kwarg because the current package doesn't have the `simulation` sub-package.

https://packaging.python.org/guides/distributing-packages-using-setuptools/#packages

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/1333)
<!-- Reviewable:end -->
