### PR TITLE
fix: Fix worksheets not changing on game server

### DIFF
--- a/aimmo/game_manager.py
+++ b/aimmo/game_manager.py
@@ -1,0 +1,138 @@
+# This will probably replace the whole aimmo-game-creator at some point.
+# For now it just duplicates a part of aimmo-game-creator/game_manager.py in order to recreate a game server.
+import logging
+import time
+
+import kubernetes
+from kubernetes.client import CoreV1Api
+from kubernetes.client.api.custom_objects_api import CustomObjectsApi
+from kubernetes.client.api_client import ApiClient
+
+LOGGER = logging.getLogger(__name__)
+
+K8S_NAMESPACE = "default"
+
+
+class GameManager:
+    def __init__(self) -> None:
+        self.api: CoreV1Api = CoreV1Api()
+        self.api_client: ApiClient = ApiClient()
+        self.custom_objects_api: CustomObjectsApi = CustomObjectsApi(self.api_client)
+
+    @staticmethod
+    def create_game_name(game_id: int) -> str:
+        """
+        Creates a name that will be used as the pod name as well as in other places.
+
+        :param game_id: Integer indicating the GAME_ID of the game.
+        :return: A string with the game appended with the id.
+        """
+        return f"game-{game_id}"
+
+    def patch_game_service(self, game_id, game_server_name):
+        patched_service = kubernetes.client.V1Service(
+            spec=kubernetes.client.V1ServiceSpec(
+                selector={"agones.dev/gameserver": game_server_name}
+            )
+        )
+        self.api.patch_namespaced_service(
+            self.create_game_name(game_id), K8S_NAMESPACE, patched_service
+        )
+
+    def create_game_server_allocation(
+        self, game_id: int, game_data: dict, retry_count: int = 0
+    ) -> str:
+        result = self.custom_objects_api.create_namespaced_custom_object(
+            group="allocation.agones.dev",
+            version="v1",
+            namespace=K8S_NAMESPACE,
+            plural="gameserverallocations",
+            body={
+                "apiVersion": "allocation.agones.dev/v1",
+                "kind": "GameServerAllocation",
+                "metadata": {"generateName": "game-allocation-"},
+                "spec": {
+                    "required": {"matchLabels": {"agones.dev/fleet": "aimmo-game"}},
+                    "scheduling": "Packed",
+                    "metadata": {
+                        "labels": {
+                            "game-id": str(game_id),
+                        },
+                        "annotations": game_data,
+                    },
+                },
+            },
+        )
+        if result["status"]["state"] == "UnAllocated" and retry_count < 60:
+            LOGGER.warning(
+                f"Failed to create game, retrying... retry_count={retry_count}"
+            )
+            time.sleep(5)
+            return self.create_game_server_allocation(
+                game_id, game_data, retry_count=retry_count + 1
+            )
+        else:
+            return result["status"]["gameServerName"]
+
+    def delete_game_server(self, game_id: int) -> dict:
+        """
+        Delete the game server with the specified game_id and return its game data.
+
+        :param game_id: Integer indicating the ID of the game to delete.
+        :returns: A dictionary representing the game data.
+        """
+        game_data = {}
+        result = self.custom_objects_api.list_namespaced_custom_object(
+            group="agones.dev",
+            version="v1",
+            namespace=K8S_NAMESPACE,
+            plural="gameservers",
+            label_selector=f"game-id={game_id}",
+        )
+        game_servers_to_delete = result["items"]
+
+        if len(game_servers_to_delete) == 0:
+            LOGGER.warning(
+                f"delete_game_server - No game server found with ID {game_id}"
+            )
+        elif len(game_servers_to_delete) > 1:
+            LOGGER.warning(
+                f"delete_game_server - Multiple game servers found with ID {game_id}"
+            )
+
+        for game_server in game_servers_to_delete:
+            name = game_server["metadata"]["name"]
+            game_data.update(game_server["metadata"]["annotations"])
+            self.custom_objects_api.delete_namespaced_custom_object(
+                group="agones.dev",
+                version="v1",
+                namespace=K8S_NAMESPACE,
+                plural="gameservers",
+                name=name,
+            )
+
+        # Remove agones specific annotations from game_data
+        game_data = {
+            k: v for k, v in game_data.items() if not k.startswith("agones.dev/")
+        }
+        return game_data
+
+    def recreate_game_server(
+        self, game_id: int, game_data_updates: dict = None
+    ) -> None:
+        """
+        Recreate a game server with the specified game_id and optionally update its game data.
+
+        :param game_id: Integer indicating the ID of the game to recreate.
+        :param game_data_updates: Optional, a dictionary with game data updates.
+        :returns: None
+        """
+        if game_data_updates is None:
+            game_data_updates = {}
+
+        game_data = self.delete_game_server(game_id=game_id)
+        game_data.update(game_data_updates)
+        game_server_name = self.create_game_server_allocation(
+            game_id=game_id, game_data=game_data
+        )
+        self.patch_game_service(game_id=game_id, game_server_name=game_server_name)

--- a/aimmo/game_manager.py
+++ b/aimmo/game_manager.py
@@ -11,6 +11,7 @@ from kubernetes.client.api_client import ApiClient
 LOGGER = logging.getLogger(__name__)
 
 K8S_NAMESPACE = "default"
+AGONES_GROUP = "agones.dev"
 
 
 class GameManager:
@@ -83,7 +84,7 @@ class GameManager:
         """
         game_data = {}
         result = self.custom_objects_api.list_namespaced_custom_object(
-            group="agones.dev",
+            group=AGONES_GROUP,
             version="v1",
             namespace=K8S_NAMESPACE,
             plural="gameservers",
@@ -104,7 +105,7 @@ class GameManager:
             name = game_server["metadata"]["name"]
             game_data.update(game_server["metadata"]["annotations"])
             self.custom_objects_api.delete_namespaced_custom_object(
-                group="agones.dev",
+                group=AGONES_GROUP,
                 version="v1",
                 namespace=K8S_NAMESPACE,
                 plural="gameservers",
@@ -113,7 +114,7 @@ class GameManager:
 
         # Remove agones specific annotations from game_data
         game_data = {
-            k: v for k, v in game_data.items() if not k.startswith("agones.dev/")
+            k: v for k, v in game_data.items() if not k.startswith(f"{AGONES_GROUP}/")
         }
         return game_data
 

--- a/aimmo/tests/test_game_manager.py
+++ b/aimmo/tests/test_game_manager.py
@@ -1,0 +1,119 @@
+import time
+from unittest.mock import DEFAULT, MagicMock
+
+import kubernetes
+import pytest
+from aimmo.game_manager import K8S_NAMESPACE, GameManager
+
+
+@pytest.fixture
+def game_manager() -> GameManager:
+    return GameManager()
+
+
+@pytest.fixture
+def game_id() -> int:
+    return 5
+
+
+@pytest.fixture
+def game_data() -> dict:
+    return {
+        "worksheet_id": "1",
+        "class_id": "3",
+        "era": "1",
+        "status": "r",
+    }
+
+
+def test_create_game_name(game_manager, game_id):
+    assert game_manager.create_game_name(game_id) == f"game-{game_id}"
+
+
+def test_patch_game_service(game_manager, game_id):
+    game_manager.api.patch_namespaced_service = MagicMock()
+    game_server_name = "test"
+    expected_service = kubernetes.client.V1Service(
+        spec=kubernetes.client.V1ServiceSpec(
+            selector={"agones.dev/gameserver": game_server_name}
+        )
+    )
+
+    game_manager.patch_game_service(game_id=game_id, game_server_name=game_server_name)
+
+    game_manager.api.patch_namespaced_service.assert_called_with(
+        game_manager.create_game_name(game_id), K8S_NAMESPACE, expected_service
+    )
+
+
+def test_create_game_server_allocation(game_manager, game_id, game_data, monkeypatch):
+    monkeypatch.setattr(time, "sleep", MagicMock)
+    unallocated_result = {"status": {"state": "UnAllocated"}}
+    game_manager.custom_objects_api.create_namespaced_custom_object = MagicMock(
+        side_effect=[unallocated_result, DEFAULT]
+    )
+
+    game_manager.create_game_server_allocation(game_id=game_id, game_data=game_data)
+
+    game_manager.custom_objects_api.create_namespaced_custom_object.assert_called_with(
+        group="allocation.agones.dev",
+        version="v1",
+        namespace=K8S_NAMESPACE,
+        plural="gameserverallocations",
+        body={
+            "apiVersion": "allocation.agones.dev/v1",
+            "kind": "GameServerAllocation",
+            "metadata": {"generateName": "game-allocation-"},
+            "spec": {
+                "required": {"matchLabels": {"agones.dev/fleet": "aimmo-game"}},
+                "scheduling": "Packed",
+                "metadata": {
+                    "labels": {
+                        "game-id": str(game_id),
+                    },
+                    "annotations": game_data,
+                },
+            },
+        },
+    )
+
+
+def test_delete_game_server(game_manager, game_id):
+    worksheet_id = "2"
+    mock_game_server = {
+        "metadata": {
+            "name": "test",
+            "annotations": {
+                "agones.dev/sdk-version": "1.12.0",
+                "worksheet_id": worksheet_id,
+            },
+        }
+    }
+    game_manager.custom_objects_api.list_namespaced_custom_object = MagicMock(
+        return_value={"items": [mock_game_server, MagicMock()]}
+    )
+    game_manager.custom_objects_api.delete_namespaced_custom_object = MagicMock()
+
+    game_data = game_manager.delete_game_server(game_id=game_id)
+
+    assert game_data == {"worksheet_id": worksheet_id}
+
+
+def test_recreate_game_server(game_manager, game_id):
+    mock_game_data = MagicMock()
+    mock_game_server_name = MagicMock()
+    game_manager.delete_game_server = MagicMock(return_value=mock_game_data)
+    game_manager.create_game_server_allocation = MagicMock(
+        return_value=mock_game_server_name
+    )
+    game_manager.patch_game_service = MagicMock()
+
+    game_manager.recreate_game_server(game_id=game_id)
+
+    game_manager.delete_game_server.assert_called_with(game_id=game_id)
+    game_manager.create_game_server_allocation.assert_called_with(
+        game_id=game_id, game_data=mock_game_data
+    )
+    game_manager.patch_game_service.assert_called_with(
+        game_id=game_id, game_server_name=mock_game_server_name
+    )

--- a/aimmo/tests/test_views.py
+++ b/aimmo/tests/test_views.py
@@ -440,7 +440,8 @@ class TestViews(TestCase):
         avatar = game.avatar_set.get(owner=client.session["_auth_user_id"])
         assert avatar is not None
 
-    def test_update_game_worksheet_updates_avatar_codes(self):
+    @patch("aimmo.serializers.GameManager")
+    def test_update_game_worksheet_updates_avatar_codes(self, mocked_game_manager):
         # Set up the first avatar
         first_user = self.user
         models.Avatar(owner=first_user, code=self.CODE, game=self.game).save()

--- a/aimmo/tests/test_views.py
+++ b/aimmo/tests/test_views.py
@@ -441,7 +441,7 @@ class TestViews(TestCase):
         assert avatar is not None
 
     @patch("aimmo.serializers.GameManager")
-    def test_update_game_worksheet_updates_avatar_codes(self, mocked_game_manager):
+    def test_update_game_worksheet_updates_avatar_codes(self, mock_game_manager):
         # Set up the first avatar
         first_user = self.user
         models.Avatar(owner=first_user, code=self.CODE, game=self.game).save()
@@ -462,6 +462,7 @@ class TestViews(TestCase):
             content_type="application/json",
         )
 
+        assert mock_game_manager.called
         assert response.status_code == 200
 
         game = models.Game.objects.get(id=1)

--- a/aimmo/tests/test_views.py
+++ b/aimmo/tests/test_views.py
@@ -462,6 +462,7 @@ class TestViews(TestCase):
             content_type="application/json",
         )
 
+        # GameManager is called when a game is edited.
         assert mock_game_manager.called
         assert response.status_code == 200
 

--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -115,14 +115,16 @@ def get_game_url_base_and_path(game_id: int) -> str:
     )
     try:
         result_items = result["items"]
-        game_server = result_items[0]
+        game_server = None
 
-        # If there are more game servers, get one which is not marked for deletion
-        if len(result_items) > 1:
-            for item in result_items:
-                if "deletionTimestamp" not in item["metadata"]:
-                    game_server = item
-                    break
+        # Get the first game server not marked for deletion. Raise 404 if there is none.
+        for item in result_items:
+            if "deletionTimestamp" not in item["metadata"]:
+                game_server = item
+                break
+
+        if game_server is None:
+            raise Http404
 
         game_server_status = game_server["status"]
         return (

--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -114,7 +114,17 @@ def get_game_url_base_and_path(game_id: int) -> str:
         label_selector=f"game-id={game_id}",
     )
     try:
-        game_server_status = result["items"][0]["status"]
+        result_items = result["items"]
+        game_server = result_items[0]
+
+        # If there are more game servers, get one which is not marked for deletion
+        if len(result_items) > 1:
+            for item in result_items:
+                if "deletionTimestamp" not in item["metadata"]:
+                    game_server = item
+                    break
+
+        game_server_status = game_server["status"]
         return (
             f"http://{game_server_status['address']}:{game_server_status['ports'][0]['port']}",
             "/socket.io",


### PR DESCRIPTION
# Description

Duplicated part of game_manager in aimmo. Game server now gets recreated when a game worksheet gets updated.

## Testing

Tested locally by changing the worksheet on a running game server, playing it and checking the worksheet is updated. Also tested this on a stopped server.

## Checklist

- [ ] Play a game, go back and change the worksheet, play the game again and check if the worksheet changed.
- [ ] Make sure a game is stopped (wasn't accessed in the past hour). Update the worksheet and play it. It should have the correct worksheet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/1487)
<!-- Reviewable:end -->
