### PR TITLE
feat: block GA if there's no consent

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -27,7 +27,6 @@ jobs:
         run: |
           pip install pipenv
           pipenv install --dev --system
-          pip install -U -e "git+https://github.com/ocadotechnology/codeforlife-portal@managed-cookies#egg=cfl-common&subdirectory=cfl_common"  # TODO: remove this after publishing common
           cd game_frontend
           yarn --frozen-lockfile
       - name: Run Javascript tests

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           pip install pipenv
           pipenv install --dev --system
+          pip install -U -e git+https://github.com/ocadotechnology/codeforlife-portal@managed-cookies#egg=cfl-common&subdirectory=cfl_common  # TODO: remove this after publishing common
           cd game_frontend
           yarn --frozen-lockfile
       - name: Run Javascript tests

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           pip install pipenv
           pipenv install --dev --system
-          pip install -U -e git+https://github.com/ocadotechnology/codeforlife-portal@managed-cookies#egg=cfl-common&subdirectory=cfl_common  # TODO: remove this after publishing common
+          pip install -U -e "git+https://github.com/ocadotechnology/codeforlife-portal@managed-cookies#egg=cfl-common&subdirectory=cfl_common"  # TODO: remove this after publishing common
           cd game_frontend
           yarn --frozen-lockfile
       - name: Run Javascript tests

--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ pytest-django = "==4.1.0"
 pytest-pythonpath = "*"
 codeforlife-portal = "*"
 pytest-cov = "*"
+black = "*"
 
 [packages]
 aimmo = {editable = true,path = "."}
@@ -20,3 +21,6 @@ wheel = "*"
 
 [requires]
 python_version = "3.7"
+
+[pipenv]
+allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -69,10 +69,10 @@
         },
         "cfl-common": {
             "hashes": [
-                "sha256:d31d0c76d35696e238124ee8146ddf553672a3d8aa720354c3efbcfc2b0b3776",
-                "sha256:f2a432fe457c064d3a0eda287389316e5757f07c38bca1fe96ab39baf37f1b71"
+                "sha256:2e1918f3019aa93441b386acca5a509951c57bad20f821e810567f453cc10322",
+                "sha256:3b0ed3eb69fde08ec6888f6d8762fa4de8df308a39c3cf031d3b7f6294bba5ec"
             ],
-            "version": "==4.28.0"
+            "version": "==4.28.1"
         },
         "chardet": {
             "hashes": [
@@ -665,10 +665,10 @@
         },
         "cfl-common": {
             "hashes": [
-                "sha256:d31d0c76d35696e238124ee8146ddf553672a3d8aa720354c3efbcfc2b0b3776",
-                "sha256:f2a432fe457c064d3a0eda287389316e5757f07c38bca1fe96ab39baf37f1b71"
+                "sha256:2e1918f3019aa93441b386acca5a509951c57bad20f821e810567f453cc10322",
+                "sha256:3b0ed3eb69fde08ec6888f6d8762fa4de8df308a39c3cf031d3b7f6294bba5ec"
             ],
-            "version": "==4.28.0"
+            "version": "==4.28.1"
         },
         "chardet": {
             "hashes": [
@@ -687,11 +687,11 @@
         },
         "codeforlife-portal": {
             "hashes": [
-                "sha256:0bb1be79b7c9d0294c9d793233b4680f13e621ed3fa8931a6245e81ffef53f65",
-                "sha256:d8ae2004688f8f04d83e54331a02ab61efc7a1b84de4f4b8af51e37aff94932b"
+                "sha256:161b03f1259b32571abb0a74ba091260e62d999640a5c0660389398760d015c1",
+                "sha256:4344eaf00246777d40eaf24275c8f2ba3e7bfd51e2b2537f08707abbcd030899"
             ],
             "index": "pypi",
-            "version": "==4.28.0"
+            "version": "==4.28.1"
         },
         "coverage": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -69,10 +69,10 @@
         },
         "cfl-common": {
             "hashes": [
-                "sha256:1150cc279811785b0a8685494dafba7cdcd7bc02c8dba563be184cdaa9fd56a3",
-                "sha256:46c2c169952cbf74f43d75bc6dbe2df89f9b527a38b84eae1c3b07219058fcf8"
+                "sha256:d31d0c76d35696e238124ee8146ddf553672a3d8aa720354c3efbcfc2b0b3776",
+                "sha256:f2a432fe457c064d3a0eda287389316e5757f07c38bca1fe96ab39baf37f1b71"
             ],
-            "version": "==4.26.0"
+            "version": "==4.28.0"
         },
         "chardet": {
             "hashes": [
@@ -215,11 +215,11 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:186fe2564634d67fbbb64f3daf8bc8c9cecbb2a7f535ed1a8a71795e50db8d87",
-                "sha256:70b39558712826e41f65e5f05a8d879361deaf84df8883e5dd0ec3d0da6ab66e"
+                "sha256:010f011c4e27d3d5eb01106fba6aac39d164842dfcd8709955c4638f5b11ccf8",
+                "sha256:f30a672a64d91cc2e3137765d088c5deec26416246f7a9e956eaf69a8d7ed49c"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.28.1"
+            "version": "==1.29.0"
         },
         "greenlet": {
             "hashes": [
@@ -584,10 +584,10 @@
         },
         "xlsxwriter": {
             "hashes": [
-                "sha256:2b7e22b1268c2ed85d73e5629097c9a63357f2429667ada9863cd05ff8ee33aa",
-                "sha256:30ebc19d0f201fafa34a6c622050ed2a268ac8dee24037a61605caa801dc8af5"
+                "sha256:e74dca4f2e946a117a541ca3153c06466190a88bb67fcdbd1cba2c1ea7f1fd76",
+                "sha256:eca2e737d0b8df3cd72520fadcda9f48c3581282639965125a86ea8cd04620cf"
             ],
-            "version": "==1.3.8"
+            "version": "==1.3.9"
         },
         "xlwt": {
             "hashes": [
@@ -665,10 +665,10 @@
         },
         "cfl-common": {
             "hashes": [
-                "sha256:1150cc279811785b0a8685494dafba7cdcd7bc02c8dba563be184cdaa9fd56a3",
-                "sha256:46c2c169952cbf74f43d75bc6dbe2df89f9b527a38b84eae1c3b07219058fcf8"
+                "sha256:d31d0c76d35696e238124ee8146ddf553672a3d8aa720354c3efbcfc2b0b3776",
+                "sha256:f2a432fe457c064d3a0eda287389316e5757f07c38bca1fe96ab39baf37f1b71"
             ],
-            "version": "==4.26.0"
+            "version": "==4.28.0"
         },
         "chardet": {
             "hashes": [
@@ -687,11 +687,11 @@
         },
         "codeforlife-portal": {
             "hashes": [
-                "sha256:902682d3661a6f610d28f0f27e2778393ce308abd4a53aab1010a29c19d526bf",
-                "sha256:dd55d904e7d9877392e0727fb499455cdaa8e02dcb749171a33c7807ce30e778"
+                "sha256:0bb1be79b7c9d0294c9d793233b4680f13e621ed3fa8931a6245e81ffef53f65",
+                "sha256:d8ae2004688f8f04d83e54331a02ab61efc7a1b84de4f4b8af51e37aff94932b"
             ],
             "index": "pypi",
-            "version": "==4.26.0"
+            "version": "==4.28.0"
         },
         "coverage": {
             "hashes": [
@@ -931,11 +931,11 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:186fe2564634d67fbbb64f3daf8bc8c9cecbb2a7f535ed1a8a71795e50db8d87",
-                "sha256:70b39558712826e41f65e5f05a8d879361deaf84df8883e5dd0ec3d0da6ab66e"
+                "sha256:010f011c4e27d3d5eb01106fba6aac39d164842dfcd8709955c4638f5b11ccf8",
+                "sha256:f30a672a64d91cc2e3137765d088c5deec26416246f7a9e956eaf69a8d7ed49c"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.28.1"
+            "version": "==1.29.0"
         },
         "greenlet": {
             "hashes": [
@@ -1009,6 +1009,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:2ec0faae539743ae6aaa84b49a169670a465f7f5d64e6add98388cc29fd1f2f6",
+                "sha256:c9356b657de65c53744046fa8f7358afe0714a1af7d570c00c3835c2d724a7c1"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==3.10.1"
         },
         "iniconfig": {
             "hashes": [
@@ -1298,10 +1306,10 @@
         },
         "rapid-router": {
             "hashes": [
-                "sha256:13d7d54ddb0cceab406ce86ed697e9a7b51caf0fa7d8673bcb88161a03e18b57",
-                "sha256:7628e9df3da574138be23d8b121bf56ff7fd7065d1c14ea4009983c76aa983e3"
+                "sha256:32667a40ab25a1bc61b52b4f114c52dec4d356eb17439d8a684be7ea9763b23a",
+                "sha256:420e9b772ec0f0bf770d0c972a8a229f2b0beb81cb44dbf4b7c78cef7a74d3a7"
             ],
-            "version": "==2.5.8"
+            "version": "==2.6.0"
         },
         "regex": {
             "hashes": [
@@ -1567,10 +1575,10 @@
         },
         "xlsxwriter": {
             "hashes": [
-                "sha256:2b7e22b1268c2ed85d73e5629097c9a63357f2429667ada9863cd05ff8ee33aa",
-                "sha256:30ebc19d0f201fafa34a6c622050ed2a268ac8dee24037a61605caa801dc8af5"
+                "sha256:e74dca4f2e946a117a541ca3153c06466190a88bb67fcdbd1cba2c1ea7f1fd76",
+                "sha256:eca2e737d0b8df3cd72520fadcda9f48c3581282639965125a86ea8cd04620cf"
             ],
-            "version": "==1.3.8"
+            "version": "==1.3.9"
         },
         "xlwt": {
             "hashes": [
@@ -1578,6 +1586,14 @@
                 "sha256:c59912717a9b28f1a3c2a98fd60741014b06b043936dcecbc113eaaada156c88"
             ],
             "version": "==1.3.0"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76",
+                "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.4.1"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6f9861bd8a615e41855cdd871dd8c5856d2a497dd702e0c80af98693177d5fab"
+            "sha256": "84e9011cb85f64cf69b554df22c65ab3780d91ebbbbf031f1f171afb56a0a656"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -69,10 +69,10 @@
         },
         "cfl-common": {
             "hashes": [
-                "sha256:2fab20615b42691dd2117fafce0318ea948188c873f7d68e445550b0c802d4b9",
-                "sha256:5b0955a74779ebb6a04ee4aa27a96862a9171b087bdb601f9df3eabfb3d321dd"
+                "sha256:1150cc279811785b0a8685494dafba7cdcd7bc02c8dba563be184cdaa9fd56a3",
+                "sha256:46c2c169952cbf74f43d75bc6dbe2df89f9b527a38b84eae1c3b07219058fcf8"
             ],
-            "version": "==4.21.3"
+            "version": "==4.26.0"
         },
         "chardet": {
             "hashes": [
@@ -132,10 +132,10 @@
         },
         "django-otp": {
             "hashes": [
-                "sha256:8ba5ab9bd2738c7321376c349d7cce49cf4404e79f6804e0a3cc462a91728e18",
-                "sha256:f523fb9dec420f28a29d3e2ad72ac06f64588956ed4f2b5b430d8e957ebb8287"
+                "sha256:381a15e65293b8b06d47b7d6b306e0b7af2e104137ac92f6c566d3b9b90b6244",
+                "sha256:f4ab096b424c33ffe69453620356e1b7517f30dfb9ba13bfeaa1d1f20faddc13"
             ],
-            "version": "==1.0.2"
+            "version": "==1.0.3"
         },
         "django-phonenumber-field": {
             "hashes": [
@@ -186,11 +186,11 @@
         },
         "docker": {
             "hashes": [
-                "sha256:d3393c878f575d3a9ca3b94471a3c89a6d960b35feb92f033c0de36cc9d934db",
-                "sha256:f3607d5695be025fa405a12aca2e5df702a57db63790c73b927eb6a94aac60af"
+                "sha256:3e8bc47534e0ca9331d72c32f2881bb13b93ded0bcdeab3c833fb7cf61c0a9a5",
+                "sha256:fc961d622160e8021c10d1bcabc388c57d55fb1f917175afbe24af442e6879bd"
             ],
             "index": "pypi",
-            "version": "==4.4.4"
+            "version": "==5.0.0"
         },
         "draftjs-exporter": {
             "hashes": [
@@ -215,11 +215,11 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:9bd436d19ab047001a1340720d2b629eb96dd503258c524921ec2af3ee88a80e",
-                "sha256:dcaba3aa9d4e0e96fd945bf25a86b6f878fcb05770b67adbeb50a63ca4d28a5e"
+                "sha256:186fe2564634d67fbbb64f3daf8bc8c9cecbb2a7f535ed1a8a71795e50db8d87",
+                "sha256:70b39558712826e41f65e5f05a8d879361deaf84df8883e5dd0ec3d0da6ab66e"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.28.0"
+            "version": "==1.28.1"
         },
         "greenlet": {
             "hashes": [
@@ -325,42 +325,42 @@
         },
         "pillow": {
             "hashes": [
-                "sha256:15306d71a1e96d7e271fd2a0737038b5a92ca2978d2e38b6ced7966583e3d5af",
-                "sha256:1940fc4d361f9cc7e558d6f56ff38d7351b53052fd7911f4b60cd7bc091ea3b1",
-                "sha256:1f93f2fe211f1ef75e6f589327f4d4f8545d5c8e826231b042b483d8383e8a7c",
-                "sha256:30d33a1a6400132e6f521640dd3f64578ac9bfb79a619416d7e8802b4ce1dd55",
-                "sha256:328240f7dddf77783e72d5ed79899a6b48bc6681f8d1f6001f55933cb4905060",
-                "sha256:46c2bcf8e1e75d154e78417b3e3c64e96def738c2a25435e74909e127a8cba5e",
-                "sha256:5762ebb4436f46b566fc6351d67a9b5386b5e5de4e58fdaa18a1c83e0e20f1a8",
-                "sha256:5a2d957eb4aba9d48170b8fe6538ec1fbc2119ffe6373782c03d8acad3323f2e",
-                "sha256:5cf03b9534aca63b192856aa601c68d0764810857786ea5da652581f3a44c2b0",
-                "sha256:5daba2b40782c1c5157a788ec4454067c6616f5a0c1b70e26ac326a880c2d328",
-                "sha256:63cd413ac52ee3f67057223d363f4f82ce966e64906aea046daf46695e3c8238",
-                "sha256:6efac40344d8f668b6c4533ae02a48d52fd852ef0654cc6f19f6ac146399c733",
-                "sha256:71b01ee69e7df527439d7752a2ce8fb89e19a32df484a308eca3e81f673d3a03",
-                "sha256:71f31ee4df3d5e0b366dd362007740106d3210fb6a56ec4b581a5324ba254f06",
-                "sha256:72027ebf682abc9bafd93b43edc44279f641e8996fb2945104471419113cfc71",
-                "sha256:74cd9aa648ed6dd25e572453eb09b08817a1e3d9f8d1bd4d8403d99e42ea790b",
-                "sha256:81b3716cc9744ffdf76b39afb6247eae754186838cedad0b0ac63b2571253fe6",
-                "sha256:8565355a29655b28fdc2c666fd9a3890fe5edc6639d128814fafecfae2d70910",
-                "sha256:87f42c976f91ca2fc21a3293e25bd3cd895918597db1b95b93cbd949f7d019ce",
-                "sha256:89e4c757a91b8c55d97c91fa09c69b3677c227b942fa749e9a66eef602f59c28",
-                "sha256:8c4e32218c764bc27fe49b7328195579581aa419920edcc321c4cb877c65258d",
-                "sha256:903293320efe2466c1ab3509a33d6b866dc850cfd0c5d9cc92632014cec185fb",
-                "sha256:90882c6f084ef68b71bba190209a734bf90abb82ab5e8f64444c71d5974008c6",
-                "sha256:98afcac3205d31ab6a10c5006b0cf040d0026a68ec051edd3517b776c1d78b09",
-                "sha256:a01da2c266d9868c4f91a9c6faf47a251f23b9a862dce81d2ff583135206f5be",
-                "sha256:aeab4cd016e11e7aa5cfc49dcff8e51561fa64818a0be86efa82c7038e9369d0",
-                "sha256:b07c660e014852d98a00a91adfbe25033898a9d90a8f39beb2437d22a203fc44",
-                "sha256:bead24c0ae3f1f6afcb915a057943ccf65fc755d11a1410a909c1fefb6c06ad1",
-                "sha256:d1d6bca39bb6dd94fba23cdb3eeaea5e30c7717c5343004d900e2a63b132c341",
-                "sha256:e2cd8ac157c1e5ae88b6dd790648ee5d2777e76f1e5c7d184eaddb2938594f34",
-                "sha256:e5739ae63636a52b706a0facec77b2b58e485637e1638202556156e424a02dc2",
-                "sha256:f36c3ff63d6fc509ce599a2f5b0d0732189eed653420e7294c039d342c6e204a",
-                "sha256:f91b50ad88048d795c0ad004abbe1390aa1882073b1dca10bfd55d0b8cf18ec5"
+                "sha256:01425106e4e8cee195a411f729cff2a7d61813b0b11737c12bd5991f5f14bcd5",
+                "sha256:031a6c88c77d08aab84fecc05c3cde8414cd6f8406f4d2b16fed1e97634cc8a4",
+                "sha256:083781abd261bdabf090ad07bb69f8f5599943ddb539d64497ed021b2a67e5a9",
+                "sha256:0d19d70ee7c2ba97631bae1e7d4725cdb2ecf238178096e8c82ee481e189168a",
+                "sha256:0e04d61f0064b545b989126197930807c86bcbd4534d39168f4aa5fda39bb8f9",
+                "sha256:12e5e7471f9b637762453da74e390e56cc43e486a88289995c1f4c1dc0bfe727",
+                "sha256:22fd0f42ad15dfdde6c581347eaa4adb9a6fc4b865f90b23378aa7914895e120",
+                "sha256:238c197fc275b475e87c1453b05b467d2d02c2915fdfdd4af126145ff2e4610c",
+                "sha256:3b570f84a6161cf8865c4e08adf629441f56e32f180f7aa4ccbd2e0a5a02cba2",
+                "sha256:463822e2f0d81459e113372a168f2ff59723e78528f91f0bd25680ac185cf797",
+                "sha256:4d98abdd6b1e3bf1a1cbb14c3895226816e666749ac040c4e2554231068c639b",
+                "sha256:5afe6b237a0b81bd54b53f835a153770802f164c5570bab5e005aad693dab87f",
+                "sha256:5b70110acb39f3aff6b74cf09bb4169b167e2660dabc304c1e25b6555fa781ef",
+                "sha256:5cbf3e3b1014dddc45496e8cf38b9f099c95a326275885199f427825c6522232",
+                "sha256:624b977355cde8b065f6d51b98497d6cd5fbdd4f36405f7a8790e3376125e2bb",
+                "sha256:63728564c1410d99e6d1ae8e3b810fe012bc440952168af0a2877e8ff5ab96b9",
+                "sha256:66cc56579fd91f517290ab02c51e3a80f581aba45fd924fcdee01fa06e635812",
+                "sha256:6c32cc3145928c4305d142ebec682419a6c0a8ce9e33db900027ddca1ec39178",
+                "sha256:8bb1e155a74e1bfbacd84555ea62fa21c58e0b4e7e6b20e4447b8d07990ac78b",
+                "sha256:95d5ef984eff897850f3a83883363da64aae1000e79cb3c321915468e8c6add5",
+                "sha256:a013cbe25d20c2e0c4e85a9daf438f85121a4d0344ddc76e33fd7e3965d9af4b",
+                "sha256:a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1",
+                "sha256:a7d5e9fad90eff8f6f6106d3b98b553a88b6f976e51fce287192a5d2d5363713",
+                "sha256:aac00e4bc94d1b7813fe882c28990c1bc2f9d0e1aa765a5f2b516e8a6a16a9e4",
+                "sha256:b91c36492a4bbb1ee855b7d16fe51379e5f96b85692dc8210831fbb24c43e484",
+                "sha256:c03c07ed32c5324939b19e36ae5f75c660c81461e312a41aea30acdd46f93a7c",
+                "sha256:c5236606e8570542ed424849f7852a0ff0bce2c4c8d0ba05cc202a5a9c97dee9",
+                "sha256:c6b39294464b03457f9064e98c124e09008b35a62e3189d3513e5148611c9388",
+                "sha256:cb7a09e173903541fa888ba010c345893cd9fc1b5891aaf060f6ca77b6a3722d",
+                "sha256:d68cb92c408261f806b15923834203f024110a2e2872ecb0bd2a110f89d3c602",
+                "sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9",
+                "sha256:e98eca29a05913e82177b3ba3d198b1728e164869c613d76d0de4bde6768a50e",
+                "sha256:f217c3954ce5fd88303fc0c317af55d5e0204106d86dea17eb8205700d47dec2"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.1.2"
+            "version": "==8.2.0"
         },
         "pyasn1": {
             "hashes": [
@@ -584,10 +584,10 @@
         },
         "xlsxwriter": {
             "hashes": [
-                "sha256:9b1ade2d1ba5d9b40a6d1de1d55ded4394ab8002718092ae80a08532c2add2e6",
-                "sha256:b807c2d3e379bf6a925f472955beef3e07495c1bac708640696876e68675b49b"
+                "sha256:2b7e22b1268c2ed85d73e5629097c9a63357f2429667ada9863cd05ff8ee33aa",
+                "sha256:30ebc19d0f201fafa34a6c622050ed2a268ac8dee24037a61605caa801dc8af5"
             ],
-            "version": "==1.3.7"
+            "version": "==1.3.8"
         },
         "xlwt": {
             "hashes": [
@@ -609,6 +609,13 @@
             ],
             "markers": "python_version >= '3.3'",
             "version": "==0.1.7"
+        },
+        "appdirs": {
+            "hashes": [
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
+            ],
+            "version": "==1.4.4"
         },
         "attrs": {
             "hashes": [
@@ -634,6 +641,13 @@
             ],
             "version": "==4.8.2"
         },
+        "black": {
+            "hashes": [
+                "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"
+            ],
+            "index": "pypi",
+            "version": "==20.8b1"
+        },
         "cachetools": {
             "hashes": [
                 "sha256:1d9d5f567be80f7c07d765e21b814326d78c61eb0c3a637dffc0e5d1796cb2e2",
@@ -651,10 +665,10 @@
         },
         "cfl-common": {
             "hashes": [
-                "sha256:2fab20615b42691dd2117fafce0318ea948188c873f7d68e445550b0c802d4b9",
-                "sha256:5b0955a74779ebb6a04ee4aa27a96862a9171b087bdb601f9df3eabfb3d321dd"
+                "sha256:1150cc279811785b0a8685494dafba7cdcd7bc02c8dba563be184cdaa9fd56a3",
+                "sha256:46c2c169952cbf74f43d75bc6dbe2df89f9b527a38b84eae1c3b07219058fcf8"
             ],
-            "version": "==4.21.3"
+            "version": "==4.26.0"
         },
         "chardet": {
             "hashes": [
@@ -663,13 +677,21 @@
             ],
             "version": "==3.0.4"
         },
+        "click": {
+            "hashes": [
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==7.1.2"
+        },
         "codeforlife-portal": {
             "hashes": [
-                "sha256:93840d7c15f2a13c8e7d6cf9591c9ee55b0c4be9b6b93e8b8a1eb8f0c7f3d1d1",
-                "sha256:cec5831f91fa90abcfdc409600b65e22d2268f3fc395d329865c9e1d8cc9f507"
+                "sha256:902682d3661a6f610d28f0f27e2778393ce308abd4a53aab1010a29c19d526bf",
+                "sha256:dd55d904e7d9877392e0727fb499455cdaa8e02dcb749171a33c7807ce30e778"
             ],
             "index": "pypi",
-            "version": "==4.21.3"
+            "version": "==4.26.0"
         },
         "coverage": {
             "hashes": [
@@ -807,10 +829,10 @@
         },
         "django-otp": {
             "hashes": [
-                "sha256:8ba5ab9bd2738c7321376c349d7cce49cf4404e79f6804e0a3cc462a91728e18",
-                "sha256:f523fb9dec420f28a29d3e2ad72ac06f64588956ed4f2b5b430d8e957ebb8287"
+                "sha256:381a15e65293b8b06d47b7d6b306e0b7af2e104137ac92f6c566d3b9b90b6244",
+                "sha256:f4ab096b424c33ffe69453620356e1b7517f30dfb9ba13bfeaa1d1f20faddc13"
             ],
-            "version": "==1.0.2"
+            "version": "==1.0.3"
         },
         "django-phonenumber-field": {
             "hashes": [
@@ -909,11 +931,11 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:9bd436d19ab047001a1340720d2b629eb96dd503258c524921ec2af3ee88a80e",
-                "sha256:dcaba3aa9d4e0e96fd945bf25a86b6f878fcb05770b67adbeb50a63ca4d28a5e"
+                "sha256:186fe2564634d67fbbb64f3daf8bc8c9cecbb2a7f535ed1a8a71795e50db8d87",
+                "sha256:70b39558712826e41f65e5f05a8d879361deaf84df8883e5dd0ec3d0da6ab66e"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.28.0"
+            "version": "==1.28.1"
         },
         "greenlet": {
             "hashes": [
@@ -988,14 +1010,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:742add720a20d0467df2f444ae41704000f50e1234f46174b51f9c6031a1bd71",
-                "sha256:b74159469b464a99cb8cc3e21973e4d96e05d3024d337313fedb618a6e86e6f4"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==3.7.3"
-        },
         "iniconfig": {
             "hashes": [
                 "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
@@ -1043,6 +1057,13 @@
             "markers": "python_version >= '3.5'",
             "version": "==8.6.0"
         },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
         "oauthlib": {
             "hashes": [
                 "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889",
@@ -1066,6 +1087,13 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.9"
         },
+        "pathspec": {
+            "hashes": [
+                "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd",
+                "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"
+            ],
+            "version": "==0.8.1"
+        },
         "phonenumbers": {
             "hashes": [
                 "sha256:23944f9e628f32a975d3b221b6d76e6ba8ae618d53cb3d82fc23d9e100a59b29",
@@ -1075,42 +1103,42 @@
         },
         "pillow": {
             "hashes": [
-                "sha256:15306d71a1e96d7e271fd2a0737038b5a92ca2978d2e38b6ced7966583e3d5af",
-                "sha256:1940fc4d361f9cc7e558d6f56ff38d7351b53052fd7911f4b60cd7bc091ea3b1",
-                "sha256:1f93f2fe211f1ef75e6f589327f4d4f8545d5c8e826231b042b483d8383e8a7c",
-                "sha256:30d33a1a6400132e6f521640dd3f64578ac9bfb79a619416d7e8802b4ce1dd55",
-                "sha256:328240f7dddf77783e72d5ed79899a6b48bc6681f8d1f6001f55933cb4905060",
-                "sha256:46c2bcf8e1e75d154e78417b3e3c64e96def738c2a25435e74909e127a8cba5e",
-                "sha256:5762ebb4436f46b566fc6351d67a9b5386b5e5de4e58fdaa18a1c83e0e20f1a8",
-                "sha256:5a2d957eb4aba9d48170b8fe6538ec1fbc2119ffe6373782c03d8acad3323f2e",
-                "sha256:5cf03b9534aca63b192856aa601c68d0764810857786ea5da652581f3a44c2b0",
-                "sha256:5daba2b40782c1c5157a788ec4454067c6616f5a0c1b70e26ac326a880c2d328",
-                "sha256:63cd413ac52ee3f67057223d363f4f82ce966e64906aea046daf46695e3c8238",
-                "sha256:6efac40344d8f668b6c4533ae02a48d52fd852ef0654cc6f19f6ac146399c733",
-                "sha256:71b01ee69e7df527439d7752a2ce8fb89e19a32df484a308eca3e81f673d3a03",
-                "sha256:71f31ee4df3d5e0b366dd362007740106d3210fb6a56ec4b581a5324ba254f06",
-                "sha256:72027ebf682abc9bafd93b43edc44279f641e8996fb2945104471419113cfc71",
-                "sha256:74cd9aa648ed6dd25e572453eb09b08817a1e3d9f8d1bd4d8403d99e42ea790b",
-                "sha256:81b3716cc9744ffdf76b39afb6247eae754186838cedad0b0ac63b2571253fe6",
-                "sha256:8565355a29655b28fdc2c666fd9a3890fe5edc6639d128814fafecfae2d70910",
-                "sha256:87f42c976f91ca2fc21a3293e25bd3cd895918597db1b95b93cbd949f7d019ce",
-                "sha256:89e4c757a91b8c55d97c91fa09c69b3677c227b942fa749e9a66eef602f59c28",
-                "sha256:8c4e32218c764bc27fe49b7328195579581aa419920edcc321c4cb877c65258d",
-                "sha256:903293320efe2466c1ab3509a33d6b866dc850cfd0c5d9cc92632014cec185fb",
-                "sha256:90882c6f084ef68b71bba190209a734bf90abb82ab5e8f64444c71d5974008c6",
-                "sha256:98afcac3205d31ab6a10c5006b0cf040d0026a68ec051edd3517b776c1d78b09",
-                "sha256:a01da2c266d9868c4f91a9c6faf47a251f23b9a862dce81d2ff583135206f5be",
-                "sha256:aeab4cd016e11e7aa5cfc49dcff8e51561fa64818a0be86efa82c7038e9369d0",
-                "sha256:b07c660e014852d98a00a91adfbe25033898a9d90a8f39beb2437d22a203fc44",
-                "sha256:bead24c0ae3f1f6afcb915a057943ccf65fc755d11a1410a909c1fefb6c06ad1",
-                "sha256:d1d6bca39bb6dd94fba23cdb3eeaea5e30c7717c5343004d900e2a63b132c341",
-                "sha256:e2cd8ac157c1e5ae88b6dd790648ee5d2777e76f1e5c7d184eaddb2938594f34",
-                "sha256:e5739ae63636a52b706a0facec77b2b58e485637e1638202556156e424a02dc2",
-                "sha256:f36c3ff63d6fc509ce599a2f5b0d0732189eed653420e7294c039d342c6e204a",
-                "sha256:f91b50ad88048d795c0ad004abbe1390aa1882073b1dca10bfd55d0b8cf18ec5"
+                "sha256:01425106e4e8cee195a411f729cff2a7d61813b0b11737c12bd5991f5f14bcd5",
+                "sha256:031a6c88c77d08aab84fecc05c3cde8414cd6f8406f4d2b16fed1e97634cc8a4",
+                "sha256:083781abd261bdabf090ad07bb69f8f5599943ddb539d64497ed021b2a67e5a9",
+                "sha256:0d19d70ee7c2ba97631bae1e7d4725cdb2ecf238178096e8c82ee481e189168a",
+                "sha256:0e04d61f0064b545b989126197930807c86bcbd4534d39168f4aa5fda39bb8f9",
+                "sha256:12e5e7471f9b637762453da74e390e56cc43e486a88289995c1f4c1dc0bfe727",
+                "sha256:22fd0f42ad15dfdde6c581347eaa4adb9a6fc4b865f90b23378aa7914895e120",
+                "sha256:238c197fc275b475e87c1453b05b467d2d02c2915fdfdd4af126145ff2e4610c",
+                "sha256:3b570f84a6161cf8865c4e08adf629441f56e32f180f7aa4ccbd2e0a5a02cba2",
+                "sha256:463822e2f0d81459e113372a168f2ff59723e78528f91f0bd25680ac185cf797",
+                "sha256:4d98abdd6b1e3bf1a1cbb14c3895226816e666749ac040c4e2554231068c639b",
+                "sha256:5afe6b237a0b81bd54b53f835a153770802f164c5570bab5e005aad693dab87f",
+                "sha256:5b70110acb39f3aff6b74cf09bb4169b167e2660dabc304c1e25b6555fa781ef",
+                "sha256:5cbf3e3b1014dddc45496e8cf38b9f099c95a326275885199f427825c6522232",
+                "sha256:624b977355cde8b065f6d51b98497d6cd5fbdd4f36405f7a8790e3376125e2bb",
+                "sha256:63728564c1410d99e6d1ae8e3b810fe012bc440952168af0a2877e8ff5ab96b9",
+                "sha256:66cc56579fd91f517290ab02c51e3a80f581aba45fd924fcdee01fa06e635812",
+                "sha256:6c32cc3145928c4305d142ebec682419a6c0a8ce9e33db900027ddca1ec39178",
+                "sha256:8bb1e155a74e1bfbacd84555ea62fa21c58e0b4e7e6b20e4447b8d07990ac78b",
+                "sha256:95d5ef984eff897850f3a83883363da64aae1000e79cb3c321915468e8c6add5",
+                "sha256:a013cbe25d20c2e0c4e85a9daf438f85121a4d0344ddc76e33fd7e3965d9af4b",
+                "sha256:a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1",
+                "sha256:a7d5e9fad90eff8f6f6106d3b98b553a88b6f976e51fce287192a5d2d5363713",
+                "sha256:aac00e4bc94d1b7813fe882c28990c1bc2f9d0e1aa765a5f2b516e8a6a16a9e4",
+                "sha256:b91c36492a4bbb1ee855b7d16fe51379e5f96b85692dc8210831fbb24c43e484",
+                "sha256:c03c07ed32c5324939b19e36ae5f75c660c81461e312a41aea30acdd46f93a7c",
+                "sha256:c5236606e8570542ed424849f7852a0ff0bce2c4c8d0ba05cc202a5a9c97dee9",
+                "sha256:c6b39294464b03457f9064e98c124e09008b35a62e3189d3513e5148611c9388",
+                "sha256:cb7a09e173903541fa888ba010c345893cd9fc1b5891aaf060f6ca77b6a3722d",
+                "sha256:d68cb92c408261f806b15923834203f024110a2e2872ecb0bd2a110f89d3c602",
+                "sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9",
+                "sha256:e98eca29a05913e82177b3ba3d198b1728e164869c613d76d0de4bde6768a50e",
+                "sha256:f217c3954ce5fd88303fc0c317af55d5e0204106d86dea17eb8205700d47dec2"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.1.2"
+            "version": "==8.2.0"
         },
         "pluggy": {
             "hashes": [
@@ -1182,11 +1210,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9",
-                "sha256:b574b57423e818210672e07ca1fa90aaf194a4f63f3ab909a2c67ebb22913839"
+                "sha256:671238a46e4df0f3498d1c3270e5deb9b32d25134c99b7d75370a68cfbe9b634",
+                "sha256:6ad9c7bdf517a808242b998ac20063c41532a570d088d77eec1ee12b0b5574bc"
             ],
             "index": "pypi",
-            "version": "==6.2.2"
+            "version": "==6.2.3"
         },
         "pytest-cov": {
             "hashes": [
@@ -1270,10 +1298,56 @@
         },
         "rapid-router": {
             "hashes": [
-                "sha256:67374f619ed5f93440fbba924b3de218078f0fd7e3fcf102ebc6a36243167099",
-                "sha256:ff23729b69b1f58c876b41c3b04a34cbdc71b1d16405f1ed4d506799d7a53aec"
+                "sha256:13d7d54ddb0cceab406ce86ed697e9a7b51caf0fa7d8673bcb88161a03e18b57",
+                "sha256:7628e9df3da574138be23d8b121bf56ff7fd7065d1c14ea4009983c76aa983e3"
             ],
-            "version": "==2.5.7"
+            "version": "==2.5.8"
+        },
+        "regex": {
+            "hashes": [
+                "sha256:01afaf2ec48e196ba91b37451aa353cb7eda77efe518e481707e0515025f0cd5",
+                "sha256:11d773d75fa650cd36f68d7ca936e3c7afaae41b863b8c387a22aaa78d3c5c79",
+                "sha256:18c071c3eb09c30a264879f0d310d37fe5d3a3111662438889ae2eb6fc570c31",
+                "sha256:1e1c20e29358165242928c2de1482fb2cf4ea54a6a6dea2bd7a0e0d8ee321500",
+                "sha256:281d2fd05555079448537fe108d79eb031b403dac622621c78944c235f3fcf11",
+                "sha256:314d66636c494ed9c148a42731b3834496cc9a2c4251b1661e40936814542b14",
+                "sha256:32e65442138b7b76dd8173ffa2cf67356b7bc1768851dded39a7a13bf9223da3",
+                "sha256:339456e7d8c06dd36a22e451d58ef72cef293112b559010db3d054d5560ef439",
+                "sha256:3916d08be28a1149fb97f7728fca1f7c15d309a9f9682d89d79db75d5e52091c",
+                "sha256:3a9cd17e6e5c7eb328517969e0cb0c3d31fd329298dd0c04af99ebf42e904f82",
+                "sha256:47bf5bf60cf04d72bf6055ae5927a0bd9016096bf3d742fa50d9bf9f45aa0711",
+                "sha256:4c46e22a0933dd783467cf32b3516299fb98cfebd895817d685130cc50cd1093",
+                "sha256:4c557a7b470908b1712fe27fb1ef20772b78079808c87d20a90d051660b1d69a",
+                "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb",
+                "sha256:563085e55b0d4fb8f746f6a335893bda5c2cef43b2f0258fe1020ab1dd874df8",
+                "sha256:598585c9f0af8374c28edd609eb291b5726d7cbce16be6a8b95aa074d252ee17",
+                "sha256:619d71c59a78b84d7f18891fe914446d07edd48dc8328c8e149cbe0929b4e000",
+                "sha256:67bdb9702427ceddc6ef3dc382455e90f785af4c13d495f9626861763ee13f9d",
+                "sha256:6d1b01031dedf2503631d0903cb563743f397ccaf6607a5e3b19a3d76fc10480",
+                "sha256:741a9647fcf2e45f3a1cf0e24f5e17febf3efe8d4ba1281dcc3aa0459ef424dc",
+                "sha256:7c2a1af393fcc09e898beba5dd59196edaa3116191cc7257f9224beaed3e1aa0",
+                "sha256:7d9884d86dd4dd489e981d94a65cd30d6f07203d90e98f6f657f05170f6324c9",
+                "sha256:90f11ff637fe8798933fb29f5ae1148c978cccb0452005bf4c69e13db951e765",
+                "sha256:919859aa909429fb5aa9cf8807f6045592c85ef56fdd30a9a3747e513db2536e",
+                "sha256:96fcd1888ab4d03adfc9303a7b3c0bd78c5412b2bfbe76db5b56d9eae004907a",
+                "sha256:97f29f57d5b84e73fbaf99ab3e26134e6687348e95ef6b48cfd2c06807005a07",
+                "sha256:980d7be47c84979d9136328d882f67ec5e50008681d94ecc8afa8a65ed1f4a6f",
+                "sha256:a91aa8619b23b79bcbeb37abe286f2f408d2f2d6f29a17237afda55bb54e7aac",
+                "sha256:ade17eb5d643b7fead300a1641e9f45401c98eee23763e9ed66a43f92f20b4a7",
+                "sha256:b9c3db21af35e3b3c05764461b262d6f05bbca08a71a7849fd79d47ba7bc33ed",
+                "sha256:bd28bc2e3a772acbb07787c6308e00d9626ff89e3bfcdebe87fa5afbfdedf968",
+                "sha256:bf5824bfac591ddb2c1f0a5f4ab72da28994548c708d2191e3b87dd207eb3ad7",
+                "sha256:c0502c0fadef0d23b128605d69b58edb2c681c25d44574fc673b0e52dce71ee2",
+                "sha256:c38c71df845e2aabb7fb0b920d11a1b5ac8526005e533a8920aea97efb8ec6a4",
+                "sha256:ce15b6d103daff8e9fee13cf7f0add05245a05d866e73926c358e871221eae87",
+                "sha256:d3029c340cfbb3ac0a71798100ccc13b97dddf373a4ae56b6a72cf70dfd53bc8",
+                "sha256:e512d8ef5ad7b898cdb2d8ee1cb09a8339e4f8be706d27eaa180c2f177248a10",
+                "sha256:e8e5b509d5c2ff12f8418006d5a90e9436766133b564db0abaec92fd27fcee29",
+                "sha256:ee54ff27bf0afaf4c3b3a62bcd016c12c3fdb4ec4f413391a90bd38bc3624605",
+                "sha256:fa4537fb4a98fe8fde99626e4681cc644bdcf2a795038533f9f711513a862ae6",
+                "sha256:fd45ff9293d9274c5008a2054ecef86a9bfe819a67c7be1afb65e69b405b3042"
+            ],
+            "version": "==2021.4.4"
         },
         "reportlab": {
             "hashes": [
@@ -1395,6 +1469,41 @@
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
+        "typed-ast": {
+            "hashes": [
+                "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace",
+                "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff",
+                "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266",
+                "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528",
+                "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6",
+                "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808",
+                "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4",
+                "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363",
+                "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341",
+                "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04",
+                "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41",
+                "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e",
+                "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3",
+                "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899",
+                "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805",
+                "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c",
+                "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c",
+                "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39",
+                "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a",
+                "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3",
+                "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7",
+                "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f",
+                "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075",
+                "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0",
+                "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40",
+                "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428",
+                "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927",
+                "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3",
+                "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
+                "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
+            ],
+            "version": "==1.4.3"
+        },
         "typing-extensions": {
             "hashes": [
                 "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
@@ -1458,10 +1567,10 @@
         },
         "xlsxwriter": {
             "hashes": [
-                "sha256:9b1ade2d1ba5d9b40a6d1de1d55ded4394ab8002718092ae80a08532c2add2e6",
-                "sha256:b807c2d3e379bf6a925f472955beef3e07495c1bac708640696876e68675b49b"
+                "sha256:2b7e22b1268c2ed85d73e5629097c9a63357f2429667ada9863cd05ff8ee33aa",
+                "sha256:30ebc19d0f201fafa34a6c622050ed2a268ac8dee24037a61605caa801dc8af5"
             ],
-            "version": "==1.3.7"
+            "version": "==1.3.8"
         },
         "xlwt": {
             "hashes": [
@@ -1469,14 +1578,6 @@
                 "sha256:c59912717a9b28f1a3c2a98fd60741014b06b043936dcecbc113eaaada156c88"
             ],
             "version": "==1.3.0"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76",
-                "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.4.1"
         }
     }
 }

--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -102,6 +102,8 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
 ]
 
+COOKIE_MANAGEMENT_ENABLED = False
+
 
 def get_game_url_base_and_path(game_id: int) -> str:
     api_client = ApiClient()

--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -102,6 +102,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
 ]
 
+# This is used in common to enable/disable the OneTrust cookie management script
 COOKIE_MANAGEMENT_ENABLED = False
 
 

--- a/game_frontend/.eslintrc.js
+++ b/game_frontend/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
   globals: {
     pyodide: 'readonly',
     languagePluginLoader: 'readonly',
+    OnetrustActiveGroups: 'readonly',
   },
   rules: {
     'react/jsx-handler-names': 'off',

--- a/game_frontend/djangoBundler.js
+++ b/game_frontend/djangoBundler.js
@@ -13,7 +13,7 @@ const options = {
   watch: process.env.NODE_ENV !== 'production',
   minify: process.env.NODE_ENV === 'production',
   target: 'browser',
-  cache: process.env.NODE_ENV === 'production'
+  cache: process.env.NODE_ENV === 'production',
 }
 
 const templateFolder = Path.resolve(Path.join(__dirname, '../aimmo/templates/players'))
@@ -23,7 +23,7 @@ const handlebarsTemplatePath = Path.resolve(
 
 const bundler = new Bundler(file, options)
 
-function getReactURL (entryPointHTML) {
+function getReactURL(entryPointHTML) {
   const regex = /(<script src="\/static\/react\/)(.*\.js)("><\/script>\n?<script src="\/static\/react\/webWorker)/g
   return regex.exec(entryPointHTML)[2]
 }
@@ -36,21 +36,22 @@ Handlebars.registerHelper('if_eq', function (a, b, opts) {
   }
 })
 
-function generateGameIDEHTML (reactFileName) {
+function generateGameIDEHTML(reactFileName) {
   const templateString = fs.readFileSync(handlebarsTemplatePath, 'utf-8')
   const template = Handlebars.compile(templateString)
   return template({
     reactUrl: `react/${reactFileName}`,
-    environment: process.env.SERVER_ENV
+    environment: process.env.SERVER_ENV,
+    nodeEnv: process.env.NODE_ENV,
   })
 }
 
-bundler.on('bundled', bundle => {
+bundler.on('bundled', (bundle) => {
   const entryPointHTML = fs.readFileSync(bundle.name, 'utf-8')
   const reactUrl = getReactURL(entryPointHTML)
   const gameIDEHTML = generateGameIDEHTML(reactUrl)
 
-  fs.writeFile(`${templateFolder}/game_ide.html`, gameIDEHTML, error => {
+  fs.writeFile(`${templateFolder}/game_ide.html`, gameIDEHTML, (error) => {
     if (error) {
       return console.log(error)
     }

--- a/game_frontend/djangoBundler.js
+++ b/game_frontend/djangoBundler.js
@@ -42,7 +42,6 @@ function generateGameIDEHTML(reactFileName) {
   return template({
     reactUrl: `react/${reactFileName}`,
     environment: process.env.SERVER_ENV,
-    nodeEnv: process.env.NODE_ENV,
   })
 }
 

--- a/game_frontend/public/handlebars_template.html
+++ b/game_frontend/public/handlebars_template.html
@@ -3,21 +3,7 @@
 <!DOCTYPE html>
 
 <head>
-  <!-- OneTrust Cookies Consent Notice start for codeforlife.education -->
-  {{#if_eq environment "default"}}
-  <!-- Production Environment -->
-  <!-- TODO -->
-  {{else}}
-    {{#if_eq nodeEnv "production"}}
-    <!-- Non-production Deployed Environment -->
-    <script type="text/javascript" src="https://cdn-ukwest.onetrust.com/consent/26fc0b44-90c4-44e3-aaa7-335ac3d03d13-test/OtAutoBlock.js" ></script>
-    <script src="https://cdn-ukwest.onetrust.com/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="26fc0b44-90c4-44e3-aaa7-335ac3d03d13-test" ></script>
-    <script type="text/javascript">
-    function OptanonWrapper() { }
-    </script>
-    {{/if_eq}}
-  {{/if_eq}}
-  <!-- OneTrust Cookies Consent Notice end for codeforlife.education -->
+  {% include "common/onetrust_cookies_consent_notice.html" %}
 
   <!-- Google Tag Manager -->
   {{#if_eq environment "default"}}

--- a/game_frontend/public/handlebars_template.html
+++ b/game_frontend/public/handlebars_template.html
@@ -3,6 +3,20 @@
 <!DOCTYPE html>
 
 <head>
+  <!-- OneTrust Cookies Consent Notice start for codeforlife.education -->
+  {{#if_eq environment "default"}}
+  <!-- Production Environment -->
+  <!-- TODO -->
+  {{else}}
+  <!-- Non-Production Environment -->
+  <script type="text/javascript" src="https://cdn-ukwest.onetrust.com/consent/26fc0b44-90c4-44e3-aaa7-335ac3d03d13-test/OtAutoBlock.js" ></script>
+  <script src="https://cdn-ukwest.onetrust.com/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="26fc0b44-90c4-44e3-aaa7-335ac3d03d13-test" ></script>
+  <script type="text/javascript">
+  function OptanonWrapper() { }
+  </script>
+  {{/if_eq}}
+  <!-- OneTrust Cookies Consent Notice end for codeforlife.education -->
+
   <!-- Google Tag Manager -->
   {{#if_eq environment "default"}}
   <!-- Production Environment -->

--- a/game_frontend/public/handlebars_template.html
+++ b/game_frontend/public/handlebars_template.html
@@ -8,12 +8,14 @@
   <!-- Production Environment -->
   <!-- TODO -->
   {{else}}
-  <!-- Non-Production Environment -->
-  <script type="text/javascript" src="https://cdn-ukwest.onetrust.com/consent/26fc0b44-90c4-44e3-aaa7-335ac3d03d13-test/OtAutoBlock.js" ></script>
-  <script src="https://cdn-ukwest.onetrust.com/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="26fc0b44-90c4-44e3-aaa7-335ac3d03d13-test" ></script>
-  <script type="text/javascript">
-  function OptanonWrapper() { }
-  </script>
+    {{#if_eq nodeEnv "production"}}
+    <!-- Non-production Deployed Environment -->
+    <script type="text/javascript" src="https://cdn-ukwest.onetrust.com/consent/26fc0b44-90c4-44e3-aaa7-335ac3d03d13-test/OtAutoBlock.js" ></script>
+    <script src="https://cdn-ukwest.onetrust.com/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="26fc0b44-90c4-44e3-aaa7-335ac3d03d13-test" ></script>
+    <script type="text/javascript">
+    function OptanonWrapper() { }
+    </script>
+    {{/if_eq}}
   {{/if_eq}}
   <!-- OneTrust Cookies Consent Notice end for codeforlife.education -->
 

--- a/game_frontend/src/global.d.ts
+++ b/game_frontend/src/global.d.ts
@@ -1,5 +1,6 @@
 declare var pyodide: Pyodide
 declare var languagePluginLoader: Promise<void>
+declare var OnetrustActiveGroups: string
 
 interface Pyodide {
   loadPackage(packages: string[]): Promise<void>

--- a/game_frontend/src/index.js
+++ b/game_frontend/src/index.js
@@ -18,44 +18,48 @@ import ReactGA from 'react-ga'
 import GamePage from 'components/GamePage'
 import { RunCodeButtonStatus } from 'components/RunCodeButton'
 
+import { hasAnalyticsCookiesConsent } from 'redux/features/Analytics/index'
+
 enableMapSet()
 
 WebFont.load({
   typekit: {
-    id: 'mrl4ieu'
+    id: 'mrl4ieu',
   },
   google: {
-    families: ['Source Code Pro']
-  }
+    families: ['Source Code Pro'],
+  },
 })
 
-ReactGA.initialize('UA-49883146-1', {
-  debug: false,
-  testMode: process.env.NODE_ENV === 'test'
-})
+if (hasAnalyticsCookiesConsent()) {
+  ReactGA.initialize('UA-49883146-1', {
+    debug: false,
+    testMode: process.env.NODE_ENV === 'test',
+  })
 
-ReactGA.pageview(`/kurono/play/${getGameIDFromURL()}`)
+  ReactGA.pageview(`/kurono/play/${getGameIDFromURL()}`)
+}
 
 const initialState = (window.Cypress && window.initialState) || {
   editor: {
     code: {
-      code: ''
+      code: '',
     },
     runCodeButton: {
-      status: RunCodeButtonStatus.normal
-    }
+      status: RunCodeButtonStatus.normal,
+    },
   },
   game: {
     connectionParameters: {
-      game_id: getGameIDFromURL() || 1
+      game_id: getGameIDFromURL() || 1,
     },
     timeoutStatus: false,
     gameLoaded: false,
-    cameraCenteredOnUserAvatar: true
-  }
+    cameraCenteredOnUserAvatar: true,
+  },
 }
 
-function getGameIDFromURL () {
+function getGameIDFromURL() {
   const url = window.location.href
   const gameIDFinder = /\/play\/([0-9]+)/
   return gameIDFinder.exec(url)[1]

--- a/game_frontend/src/redux/features/Analytics/epics.js
+++ b/game_frontend/src/redux/features/Analytics/epics.js
@@ -1,28 +1,27 @@
 import types from './types'
 import actions from './actions'
+import { hasAnalyticsCookiesConsent } from './index'
 import ReactGA from 'react-ga'
-import { tap, mapTo } from 'rxjs/operators'
+import { tap, mapTo, filter } from 'rxjs/operators'
 import { ofType } from 'redux-observable'
 
-const sendToGoogleAnalyticsEpic = action$ =>
+const sendToGoogleAnalyticsEpic = (action$) =>
   action$.pipe(
     ofType(types.SEND_ANALYTICS_EVENT),
-    tap(action =>
-      ReactGA.event(action.payload)
-    ),
+    filter(hasAnalyticsCookiesConsent),
+    tap((action) => ReactGA.event(action.payload)),
     mapTo(actions.analyticsEventSent())
   )
 
-const sendToGoogleAnalyticsTimingEventEpic = action$ =>
+const sendToGoogleAnalyticsTimingEventEpic = (action$) =>
   action$.pipe(
     ofType(types.SEND_ANALYTICS_TIMING_EVENT),
-    tap(action =>
-      ReactGA.timing(action.payload)
-    ),
+    filter(hasAnalyticsCookiesConsent),
+    tap((action) => ReactGA.timing(action.payload)),
     mapTo(actions.analyticsTimingEventSent())
   )
 
 export default {
   sendToGoogleAnalyticsEpic,
-  sendToGoogleAnalyticsTimingEventEpic
+  sendToGoogleAnalyticsTimingEventEpic,
 }

--- a/game_frontend/src/redux/features/Analytics/epics.test.js
+++ b/game_frontend/src/redux/features/Analytics/epics.test.js
@@ -1,11 +1,13 @@
 /* eslint-env jest */
 import epics from './epics'
+import * as index from './index'
 import { TestScheduler } from 'rxjs/testing'
 import { actions } from 'features/Analytics'
 import ReactGA from 'react-ga'
 
-const deepEquals = (actual, expected) =>
-  expect(actual).toEqual(expected)
+index.hasAnalyticsCookiesConsent = jest.fn(() => true)
+
+const deepEquals = (actual, expected) => expect(actual).toEqual(expected)
 
 const createTestScheduler = (frameTimeFactor = 10) => {
   TestScheduler.frameTimeFactor = frameTimeFactor
@@ -19,27 +21,29 @@ describe('sendToGoogleAnalyticsEpic', () => {
 
     testScheduler.run(({ hot, cold, expectObservable }) => {
       const action$ = hot('--a--', {
-        a: actions.sendAnalyticsEvent('Test Category', 'Test Action', 'Test Label')
+        a: actions.sendAnalyticsEvent('Test Category', 'Test Action', 'Test Label'),
       })
 
       const state$ = null
       const output$ = epics.sendToGoogleAnalyticsEpic(action$, state$, {}, testScheduler)
 
       expectObservable(output$).toBe('--b--', {
-        b: actions.analyticsEventSent()
+        b: actions.analyticsEventSent(),
       })
     })
 
     expect(ReactGA.testModeAPI.calls).toEqual([
-      ['send',
+      [
+        'send',
         {
           eventAction: 'Test Action',
           eventCategory: 'Test Category',
           eventLabel: 'Test Label',
           eventValue: 0,
           hitType: 'event',
-          nonInteraction: false
-        }]
+          nonInteraction: false,
+        },
+      ],
     ])
   })
 })
@@ -51,26 +55,28 @@ describe('sendToGoogleAnalyticsTimingEventEpic', () => {
 
     testScheduler.run(({ hot, cold, expectObservable }) => {
       const action$ = hot('--a--', {
-        a: actions.sendAnalyticsTimingEvent('Test Category', 'Test Action', 'Test Label', 5)
+        a: actions.sendAnalyticsTimingEvent('Test Category', 'Test Action', 'Test Label', 5),
       })
 
       const state$ = null
       const output$ = epics.sendToGoogleAnalyticsTimingEventEpic(action$, state$, {}, testScheduler)
 
       expectObservable(output$).toBe('--b--', {
-        b: actions.analyticsTimingEventSent()
+        b: actions.analyticsTimingEventSent(),
       })
     })
 
     expect(ReactGA.testModeAPI.calls).toEqual([
-      ['send',
+      [
+        'send',
         {
           timingVar: 'Test Action',
           timingCategory: 'Test Category',
           timingLabel: 'Test Label',
           timingValue: 5,
-          hitType: 'timing'
-        }
-      ]])
+          hitType: 'timing',
+        },
+      ],
+    ])
   })
 })

--- a/game_frontend/src/redux/features/Analytics/index.js
+++ b/game_frontend/src/redux/features/Analytics/index.js
@@ -1,5 +1,5 @@
 function hasAnalyticsCookiesConsent() {
-  return window.OnetrustActiveGroups && window.OnetrustActiveGroups.split(',').includes('C0002')
+  return !!window.OnetrustActiveGroups && window.OnetrustActiveGroups.split(',').includes('C0002')
 }
 
 export { hasAnalyticsCookiesConsent }

--- a/game_frontend/src/redux/features/Analytics/index.js
+++ b/game_frontend/src/redux/features/Analytics/index.js
@@ -1,3 +1,8 @@
+function hasAnalyticsCookiesConsent() {
+  return window.OnetrustActiveGroups && window.OnetrustActiveGroups.split(',').includes('C0002')
+}
+
+export { hasAnalyticsCookiesConsent }
 export { default as analyticTypes } from './types'
 export { default as analyticEpics } from './epics'
 export { default as actions } from './actions'

--- a/game_frontend/src/redux/features/Analytics/index.js
+++ b/game_frontend/src/redux/features/Analytics/index.js
@@ -1,4 +1,5 @@
 function hasAnalyticsCookiesConsent() {
+  // C0002 is the Analytics Cookies category in OneTrust
   return !!window.OnetrustActiveGroups && window.OnetrustActiveGroups.split(',').includes('C0002')
 }
 

--- a/game_frontend/src/redux/features/Analytics/index.test.js
+++ b/game_frontend/src/redux/features/Analytics/index.test.js
@@ -1,0 +1,16 @@
+import { hasAnalyticsCookiesConsent } from './index'
+
+describe('hasAnalyticsCookiesConsent', () => {
+  it('returns true when OnetrustActiveGroups contains analytics cookies consent', () => {
+    window.OnetrustActiveGroups = 'C0001,C0002'
+    expect(hasAnalyticsCookiesConsent()).toBe(true)
+  })
+
+  it('returns false when OnetrustActiveGroups is not set or does not contain analytics cookies consent', () => {
+    window.OnetrustActiveGroups = undefined
+    expect(hasAnalyticsCookiesConsent()).toBe(false)
+
+    window.OnetrustActiveGroups = 'C0001,C0003'
+    expect(hasAnalyticsCookiesConsent()).toBe(false)
+  })
+})

--- a/game_frontend/src/redux/features/index.js
+++ b/game_frontend/src/redux/features/index.js
@@ -19,7 +19,7 @@ const rootReducer = combineReducers({
   game: gameReducer,
   consoleLog: consoleLogReducer,
   action: actionReducer,
-  avatarWorker: avatarWorkerReducer
+  avatarWorker: avatarWorkerReducer,
 })
 
 export { rootEpic, rootReducer }


### PR DESCRIPTION
# Description

Added `hasAnalyticsCookiesConsent` function which checks for the Analytics consent in OneTrust. This is used around ReactGA calls, blocking them if the consent is false.

## Testing

- [ ] Tested locally

## Checklist

- [ ] No Google Analytics cookies are set if Analytics Cookies consent has not been given.
- [ ] If Analytics Cookies consent has been given, Google Analytics works as before, setting cookies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/1511)
<!-- Reviewable:end -->
