### PR TITLE
fix: trigger staging deployment using actions

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -58,13 +58,19 @@ jobs:
           echo ${{ steps.game.outputs.digest }}
           echo ${{ steps.game_creator.outputs.digest }}
 
-  notify-semaphore:
-    name: Notify Semaphore
+  trigger-staging-deployment:
+    name: Trigger staging deployment
     needs: [publish-docker-images]
     runs-on: ubuntu-18.04
     steps:
-      - name: Notify Semaphore (Staging)
-        run: curl -d POST https://semaphoreci.com/api/v1/projects/${SEMAPHORE_PROJECT_ID}/master/build?auth_token=${SEMAPHORE_API_AUTH}
-        env:
-          SEMAPHORE_PROJECT_ID: ${{ secrets.SEMAPHORE_PROJECT_ID }}
-          SEMAPHORE_API_AUTH: ${{ secrets.SEMAPHORE_API_AUTH }}
+      - name: Trigger staging deployment
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          script: |
+            github.actions.createWorkflowDispatch({
+              owner: 'ocadotechnology',
+              repo: 'codeforlife-deploy-appengine',
+              workflow_id: 'deploy_staging.yml',
+              ref: 'master',
+            });


### PR DESCRIPTION
## Testing

Tested the following on push:

```
      - name: Test trigger dev deployment
        uses: actions/github-script@v4
        with:
          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
          script: |
            github.actions.createWorkflowDispatch({
              owner: 'ocadotechnology',
              repo: 'codeforlife-deploy-appengine',
              workflow_id: 'deploy_dev.yml',
              ref: 'debug-ratelimit',
            });
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/aimmo/1523)
<!-- Reviewable:end -->
