### PR TITLE
fix: Remove game-creator and move relevant logic into the aimmo django app

### DIFF
--- a/aimmo-game-creator/game_manager.py
+++ b/aimmo-game-creator/game_manager.py
@@ -18,8 +18,6 @@ from kube_components import TokenSecretCreator
 LOGGER = logging.getLogger(__name__)
 
 K8S_NAMESPACE = "default"
-NUM_BYTES_FOR_TOKEN_GENERATOR = 16
-TOKEN_MAX_LENGTH = 24
 
 
 class _GameManagerData(object):
@@ -73,12 +71,6 @@ class GameManager(object):
         self._data = _GameManagerData()
         self.games_url = games_url
         super(GameManager, self).__init__()
-
-    def _generate_game_token(self):
-        token = secrets.token_urlsafe(nbytes=NUM_BYTES_FOR_TOKEN_GENERATOR)
-        # Max length of the auth_token field in the models
-        token = token[:TOKEN_MAX_LENGTH] if len(token) > TOKEN_MAX_LENGTH else token
-        return token
 
     @abstractmethod
     def create_game(self, game_id, game_data):

--- a/aimmo-game-creator/tests/test_game_manager.py
+++ b/aimmo-game-creator/tests/test_game_manager.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import unittest
 from json import dumps
 
-from game_manager import TOKEN_MAX_LENGTH, GameManager, KubernetesGameManager
+from game_manager import GameManager, KubernetesGameManager
 from httmock import HTTMock
 from unittest.mock import MagicMock, call
 
@@ -100,11 +100,6 @@ class TestGameManager(unittest.TestCase):
             self.assertEqual(
                 self.game_manager.added_games[str(i)]["name"], "Game {}".format(i)
             )
-
-    def test_token_generation(self):
-        token = self.game_manager._generate_game_token()
-        self.assertTrue(isinstance(token, str))
-        self.assertLessEqual(len(token), TOKEN_MAX_LENGTH)
 
     def test_adding_a_game_creates_game_allocation(self):
         game_manager = KubernetesGameManager("http://test/*")

--- a/aimmo/game_manager/__init__.py
+++ b/aimmo/game_manager/__init__.py
@@ -1,0 +1,4 @@
+K8S_NAMESPACE = "default"
+AGONES_GROUP = "agones.dev"
+
+from .game_manager import GameManager

--- a/aimmo/game_manager/game_service_manager.py
+++ b/aimmo/game_manager/game_service_manager.py
@@ -1,0 +1,60 @@
+import logging
+
+import kubernetes
+from kubernetes.client import CoreV1Api
+from kubernetes.client.api.custom_objects_api import CustomObjectsApi
+from kubernetes.client.api_client import ApiClient
+from kubernetes.client.rest import ApiException
+
+from game_manager import K8S_NAMESPACE
+
+LOGGER = logging.getLogger(__name__)
+
+
+class GameServiceManager:
+    def __init__(self) -> None:
+        self.api: CoreV1Api = CoreV1Api()
+        self.api_client: ApiClient = ApiClient()
+        self.custom_objects_api: CustomObjectsApi = CustomObjectsApi(self.api_client)
+
+    def create_game_service(self, game_id, game_name, game_server_name):
+        service_manifest = kubernetes.client.V1ServiceSpec(
+            selector={"agones.dev/gameserver": game_server_name},
+            ports=[
+                kubernetes.client.V1ServicePort(
+                    name="tcp", protocol="TCP", port=80, target_port=5000
+                )
+            ],
+        )
+
+        service_metadata = kubernetes.client.V1ObjectMeta(
+            name=game_name,
+            labels={"app": "aimmo-game", "game_id": game_id},
+        )
+
+        service = kubernetes.client.V1Service(
+            metadata=service_metadata, spec=service_manifest
+        )
+        self.api.create_namespaced_service(K8S_NAMESPACE, service)
+
+    def delete_game_service(self, game_id):
+        app_label = "app=aimmo-game"
+        game_label = "game_id={}".format(game_id)
+
+        resources = self.api.list_namespaced_service(
+            namespace=K8S_NAMESPACE, label_selector=",".join([app_label, game_label])
+        )
+
+        for resource in resources.items:
+            LOGGER.info("Removing service: {}".format(resource.metadata.name))
+            self.api.delete_namespaced_service(resource.metadata.name, K8S_NAMESPACE)
+
+    def patch_game_service(self, game_id, game_name, game_server_name):
+        patched_service = kubernetes.client.V1Service(
+            spec=kubernetes.client.V1ServiceSpec(
+                selector={"agones.dev/gameserver": game_server_name}
+            )
+        )
+        self.api.patch_namespaced_service(
+            game_name, K8S_NAMESPACE, patched_service
+        )

--- a/aimmo/tests/test_game_manager.py
+++ b/aimmo/tests/test_game_manager.py
@@ -1,3 +1,4 @@
+from game_manager.game_service_manager import GameServiceManager
 import time
 from unittest.mock import DEFAULT, MagicMock, PropertyMock
 
@@ -10,7 +11,7 @@ from kubernetes.client.exceptions import ApiException
 
 @pytest.fixture
 def game_manager() -> GameManager:
-    return GameManager()
+    return GameManager(game_service_manager=MagicMock())
 
 
 @pytest.fixture
@@ -30,22 +31,6 @@ def game_data() -> dict:
 
 def test_create_game_name(game_manager, game_id):
     assert game_manager.create_game_name(game_id) == f"game-{game_id}"
-
-
-def test_patch_game_service(game_manager, game_id):
-    game_manager.api.patch_namespaced_service = MagicMock()
-    game_server_name = "test"
-    expected_service = kubernetes.client.V1Service(
-        spec=kubernetes.client.V1ServiceSpec(
-            selector={"agones.dev/gameserver": game_server_name}
-        )
-    )
-
-    game_manager.patch_game_service(game_id=game_id, game_server_name=game_server_name)
-
-    game_manager.api.patch_namespaced_service.assert_called_with(
-        game_manager.create_game_name(game_id), K8S_NAMESPACE, expected_service
-    )
 
 
 def test_create_game_server_allocation(game_manager, game_id, game_data, monkeypatch):
@@ -101,14 +86,16 @@ def test_delete_game_server(game_manager, game_id):
     assert game_data == {"worksheet_id": worksheet_id}
 
 
-def test_recreate_game_server(game_manager, game_id):
+def test_recreate_game_server(
+    game_manager: GameManager, game_id
+):
     mock_game_data = MagicMock()
     mock_game_server_name = MagicMock()
+    game_name = game_manager.create_game_name(game_id=game_id)
     game_manager.delete_game_server = MagicMock(return_value=mock_game_data)
     game_manager.create_game_server_allocation = MagicMock(
         return_value=mock_game_server_name
     )
-    game_manager.patch_game_service = MagicMock()
 
     game_manager.recreate_game_server(game_id=game_id)
 
@@ -116,8 +103,8 @@ def test_recreate_game_server(game_manager, game_id):
     game_manager.create_game_server_allocation.assert_called_with(
         game_id=game_id, game_data=mock_game_data
     )
-    game_manager.patch_game_service.assert_called_with(
-        game_id=game_id, game_server_name=mock_game_server_name
+    game_manager.game_service_manager.patch_game_service.assert_called_with(
+        game_id=game_id, game_name=game_name, game_server_name=mock_game_server_name
     )
 
 
@@ -137,7 +124,7 @@ def test_create_game_secret(game_manager, game_id):
     game_manager.api.read_namespaced_secret = MagicMock()
     game_manager.api.create_namespaced_secret = MagicMock()
     game_manager.api.patch_namespaced_secret = MagicMock()
-    aimmo.game_manager.LOGGER.exception = MagicMock()
+    aimmo.game_manager.game_manager.LOGGER.exception = MagicMock()
 
     # Test create secret success
     game_manager.api.read_namespaced_secret.side_effect = ApiException()
@@ -149,7 +136,7 @@ def test_create_game_secret(game_manager, game_id):
     # Test create secret exception
     game_manager.api.create_namespaced_secret.side_effect = ApiException()
     game_manager.create_game_secret(game_id=game_id, token=token)
-    aimmo.game_manager.LOGGER.exception.assert_called()
+    aimmo.game_manager.game_manager.LOGGER.exception.assert_called()
 
     # Test patch secret success
     game_manager.api.read_namespaced_secret.side_effect = None
@@ -161,7 +148,7 @@ def test_create_game_secret(game_manager, game_id):
     # Test patch secret exception
     game_manager.api.patch_namespaced_secret.side_effect = ApiException()
     game_manager.create_game_secret(game_id=game_id, token=token)
-    aimmo.game_manager.LOGGER.exception.assert_called()
+    aimmo.game_manager.game_manager.LOGGER.exception.assert_called()
 
 
 def test_delete_game_secret(game_manager, game_id):

--- a/aimmo/tests/test_game_service_manager.py
+++ b/aimmo/tests/test_game_service_manager.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock
+
+import kubernetes
+import pytest
+from game_manager import K8S_NAMESPACE
+from game_manager.game_service_manager import GameServiceManager
+from kubernetes.client import V1ObjectMeta, V1Service, V1ServiceList, V1ServiceSpec
+
+from .test_game_manager import game_id
+
+
+@pytest.fixture
+def game_service_manager():
+    manager = GameServiceManager()
+    manager.api = MagicMock()
+    manager.api_client = MagicMock()
+    manager.custom_objects_api = MagicMock()
+    return manager
+
+
+def test_create_game_service(game_service_manager: GameServiceManager, game_id):
+    game_name = "test-game-name"
+    game_server_name = "test-game-server"
+    expected_service_spec = V1Service(
+        metadata=V1ObjectMeta(
+            name=game_name, labels={"app": "aimmo-game", "game_id": game_id}
+        ),
+        spec=V1ServiceSpec(
+            selector={"agones.dev/gameserver": game_server_name},
+            ports=[
+                kubernetes.client.V1ServicePort(
+                    name="tcp", protocol="TCP", port=80, target_port=5000
+                )
+            ],
+        ),
+    )
+    game_service_manager.create_game_service(
+        game_id=game_id,
+        game_name=game_name,
+        game_server_name=game_server_name,
+    )
+
+    game_service_manager.api.create_namespaced_service.assert_called_with(
+        K8S_NAMESPACE,
+        expected_service_spec,
+    )
+
+
+def test_delete_game_service(game_service_manager: GameServiceManager, game_id):
+    FakeServiceListResult = namedtuple("FakeServiceListResult", ["items"])
+    test_resource_name = "test-game-service"
+    game_service_manager.api.list_namespaced_service.return_value = V1ServiceList(
+        items=[
+            V1Service(
+                metadata=V1ObjectMeta(name=test_resource_name),
+            )
+        ]
+    )
+
+    game_service_manager.delete_game_service(game_id=game_id)
+
+    game_service_manager.api.delete_namespaced_service.assert_called_with(
+        test_resource_name,
+        K8S_NAMESPACE,
+    )
+
+
+def test_patch_game_service(game_service_manager: GameServiceManager, game_id):
+    game_name = "test-game-name"
+    game_server_name = "test"
+    expected_service = V1Service(
+        spec=V1ServiceSpec(selector={"agones.dev/gameserver": game_server_name})
+    )
+
+    game_service_manager.patch_game_service(
+        game_id=game_id,
+        game_name=game_name,
+        game_server_name=game_server_name,
+    )
+
+    game_service_manager.api.patch_namespaced_service.assert_called_with(
+        game_name, K8S_NAMESPACE, expected_service
+    )


### PR DESCRIPTION
Now that the Django code can communicate with the kubernetes cluster, `aimmo-game-creator` is not needed. This PR removes it.

Planning to make:
- [ ] GameServiceManager
- [ ] GameServerAllocationManager
- [ ] GameIngressManager

The `GameManager` can then just use these managers to call the relevant code.
